### PR TITLE
feat: Add show derivation

### DIFF
--- a/src/core/adt/index.js
+++ b/src/core/adt/index.js
@@ -24,5 +24,6 @@
  */
 module.exports = {
   data: require('./core'),
-  setoid: require('./setoid')
+  setoid: require('./setoid'),
+  show: require('./show')
 };

--- a/src/core/adt/show.js
+++ b/src/core/adt/show.js
@@ -1,11 +1,29 @@
 const { tagSymbol, typeSymbol } = require('./core');
 
-const displayValues = (object) => Object.getOwnPropertyNames(object)
-    .map((key) => object[key])
-    .join(', ');
+const objectToKeyValuePairs = (object) =>
+  Object.keys(object).map((key) => `${key}: ${showValue(object[key])}`).join(', ');
+
+const plainObjectToString = function() {
+  return `{ ${objectToKeyValuePairs(this)} }`;
+};
+
+const arrayToString = function() {
+  return `[${this.map(showValue).join(', ')}]`;
+};
+
+const nullToString = () => 'null';
+
+const objectToString = (object) => {
+  return object === null                                ?  nullToString
+  :      object.toString === Array.prototype.toString   ?  arrayToString
+  :      object.toString === Object.prototype.toString  ?  plainObjectToString
+  :      /* otherwise */                                   object.toString;
+};
+
+const showValue = (value) =>
+  typeof value !== 'object' ? JSON.stringify(value) : objectToString(value).call(value);
 
 module.exports = (variant, adt) => {
-
   const typeName = adt[typeSymbol];
   const variantName = `${adt[typeSymbol]}.${variant.prototype[tagSymbol]}`;
 
@@ -16,7 +34,7 @@ module.exports = (variant, adt) => {
   adt.toString               = () => typeName;
   variant.toString           = () => variantName;
   variant.prototype.toString = function() {
-    return `${variantName}(${displayValues(this)})`;
+    return `${variantName}(${plainObjectToString.call(this)})`;
   };
   // (Node REPL representations)
   adt.inspect                = adt.toString;

--- a/src/core/adt/show.js
+++ b/src/core/adt/show.js
@@ -14,14 +14,17 @@ const arrayToString = function() {
 const nullToString = () => 'null';
 
 const objectToString = (object) => {
-  return object === null                                ?  nullToString
-  :      object.toString === Array.prototype.toString   ?  arrayToString
-  :      object.toString === Object.prototype.toString  ?  plainObjectToString
-  :      /* otherwise */                                   object.toString;
+  return object === null                        ? nullToString
+  :      Array.isArray(object)                  ? arrayToString
+  :      object.toString() === ({}).toString()  ? plainObjectToString
+  :      /* otherwise */                          object.toString;
 };
 
-const showValue = (value) =>
-  typeof value !== 'object' ? JSON.stringify(value) : objectToString(value).call(value);
+const showValue = (value) => {
+  return typeof value === 'undefined' ? 'undefined'
+  :      typeof value !== 'object'    ? JSON.stringify(value)
+  :      /* otherwise */                objectToString(value).call(value);
+};
 
 module.exports = (variant, adt) => {
   const typeName = adt[typeSymbol];
@@ -42,3 +45,4 @@ module.exports = (variant, adt) => {
   variant.prototype.inspect  = variant.prototype.toString;
   return variant;
 };
+

--- a/src/core/adt/show.js
+++ b/src/core/adt/show.js
@@ -1,0 +1,26 @@
+const { tagSymbol, typeSymbol } = require('./core');
+
+const displayValues = (object) => Object.getOwnPropertyNames(object)
+    .map((key) => object[key])
+    .join(', ');
+
+module.exports = (variant, adt) => {
+
+  const typeName = adt[typeSymbol];
+  const variantName = `${adt[typeSymbol]}.${variant.prototype[tagSymbol]}`;
+
+  // (for Object.prototype.toString)
+  adt[Symbol.toStringTag]               = typeName;
+  variant.prototype[Symbol.toStringTag] = variantName;
+  // (regular JavaScript representations)
+  adt.toString               = () => typeName;
+  variant.toString           = () => variantName;
+  variant.prototype.toString = function() {
+    return `${variantName}(${displayValues(this)})`;
+  };
+  // (Node REPL representations)
+  adt.inspect                = adt.toString;
+  variant.inspect            = variant.toString;
+  variant.prototype.inspect  = variant.prototype.toString;
+  return variant;
+};

--- a/src/data/either/core.js
+++ b/src/data/either/core.js
@@ -1,11 +1,11 @@
 const assertType = require('../../helpers/assertType');
-const { data, setoid } = require('folktale/core/adt/');
+const { data, setoid, show } = require('folktale/core/adt/');
 const fl   = require('fantasy-land');
 
 const Either = data('folktale:Data.Either', {
   Left(value)  { return { value } },
   Right(value) { return { value } }
-}).derive(setoid);
+}).derive(setoid, show);
 
 const { Left, Right } = Either;
 
@@ -55,27 +55,6 @@ Right.prototype[fl.chain] = function(transformation) {
 };
 
 
-// -- Show -------------------------------------------------------------
-
-// (for Object.prototype.toString)
-Either[Symbol.toStringTag]    = '(folktale) Either';
-Left.prototype[Symbol.toStringTag]  = '(folktale) Either.Left';
-Right.prototype[Symbol.toStringTag] = '(folktale) Either.Right';
-
-// (regular JavaScript representations)
-Either.toString = () => '(folktale) Either';
-Left.prototype.toString = function() {
-  return `(folktale) Either.Left(${this.value})`;
-};
-
-Right.prototype.toString = function() {
-  return `(folktale) Either.Right(${this.value})`;
-};
-
-// (Node REPL representations)
-Either.inspect = Either.toString;
-Left.prototype.inspect  = Left.prototype.toString;
-Right.prototype.inspect = Right.prototype.toString;
 
 
 // -- Extracting values and recovering ---------------------------------

--- a/test/core.adt.es6
+++ b/test/core.adt.es6
@@ -58,8 +58,14 @@ describe('Data.ADT.derive', function() {
     property('Variants have a string representation', function() {
       return AB.A.toString()  === 'AB.A';
     })
-    property('Values have a string representation', function() {
-      return AB.A(1).toString()  === 'AB.A(1)';
+    property('Primitive Values have a string representation', function() {
+      return AB.A(1).toString()  === 'AB.A({ value: 1 })';
+    })
+    property('Complex Values have a string representation', function() {
+      return AB.A({foo: "bar"}).toString()  === 'AB.A({ value: { foo: "bar" } })';
+    })
+    property('Recursive Values have a string representation', function() {
+      return AB.A({rec:AB.A(1)}).toString()  ===  'AB.A({ value: { rec: AB.A({ value: 1 }) } })'
     })
   });
 });

--- a/test/core.adt.es6
+++ b/test/core.adt.es6
@@ -11,7 +11,7 @@
 //----------------------------------------------------------------------
 
 const { property, forall} = require('jsverify');
-const {data, setoid} = require('../core/adt/')
+const {data, setoid, show} = require('../core/adt/')
 
 describe('Data.ADT.derive', function() {
   describe('Setoid', function() {
@@ -43,5 +43,23 @@ describe('Data.ADT.derive', function() {
         return A({id:1, _irrelevantValue:a}).equals(A({id:1, _irrelevantValue: b}))
       });
     });
+  });
+  describe('Show', function() {
+    const AB = data('AB', {
+      A: (value) => ({ value }),
+      B: (value) => ({ value })
+    }).derive(show)
+
+    property('Types have a string representation', function() {
+      debugger
+      return AB.toString()  === 'AB';
+    })
+
+    property('Variants have a string representation', function() {
+      return AB.A.toString()  === 'AB.A';
+    })
+    property('Values have a string representation', function() {
+      return AB.A(1).toString()  === 'AB.A(1)';
+    })
   });
 });


### PR DESCRIPTION
I took the code from the 'Either' module and put it into a generic derivation.

Added a representation for the constructor functions (All other values have one, so I think it makes sense).

Using `getOwnPropertyNames` for listing the properties for a given value, because according to [section 14.4.2 from this source](http://exploringjs.com/es6/ch_oop-besides-classes.html) it returns the values in a deterministic order. According to the [MDN docs it doesn't](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames).  In practice both `getOwnPropertyNames` and `Object.keys` work fine. Not so important  since AFAIK names are just for debugging purpose.  We may event consider switching to `keys` to prevent the displaying of non-enumerable properties. What do you think?