### PR TITLE
feat: Add serializations

### DIFF
--- a/src/core/adt/index.js
+++ b/src/core/adt/index.js
@@ -25,5 +25,6 @@
 module.exports = {
   data: require('./core'),
   setoid: require('./setoid'),
-  show: require('./show')
+  show: require('./show'),
+  serialize: require('./serialize')
 };

--- a/src/core/adt/serialize.js
+++ b/src/core/adt/serialize.js
@@ -1,6 +1,17 @@
 const { tagSymbol, typeSymbol } = require('./core');
 const mapValues = require('folktale/core/object/map-values');
 
+const values = require('folktale/core/object/values');
+
+const arrayToObject = (extractKey) => (array) => array.reduce((object, element) => {
+  object[extractKey(element)] = element;
+  return object;
+}, {});
+
+const property = (propertyName) => (object) => object[propertyName];
+
+const indexByType = arrayToObject(property(typeSymbol));
+
 const typeJsonKey = '@@type';
 const tagJsonKey = '@@tag';
 const valueJsonKey = '@@value';
@@ -14,11 +25,12 @@ const assertType = (given, expected) => {
     `);
   }
 };
+
 const parseValue = (parsers) => (value) => {
   if (value !== null && typeof value[typeJsonKey] === 'string') {
     const type = value[typeJsonKey];
     if (parsers[type]) {
-      return parsers[type].fromJSON(value, parsers);
+      return parsers[type].fromJSON(value, parsers, true);
     } else {
       return value;
     }
@@ -29,23 +41,30 @@ const parseValue = (parsers) => (value) => {
 
 const serializeValue = (value) =>
   value !== null && typeof value.toJSON === 'function' ? value.toJSON()
-  : /* else */                                           value;
+  : /* otherwise */                                      value;
 
 module.exports = (variant, adt) => {
   const typeName = adt[typeSymbol];
   const tagName = variant.prototype[tagSymbol];
 
   variant.prototype.toJSON = function() {
-    return { [typeJsonKey]: typeName, [tagJsonKey]: tagName, [valueJsonKey]: mapValues(this, serializeValue) };
+    return { 
+      [typeJsonKey]:  typeName, 
+      [tagJsonKey]:   tagName, 
+      [valueJsonKey]: mapValues(this, serializeValue) 
+    };
   };
 
-  adt.fromJSON = function(value, parsers = { [typeName]: adt }) {
+  adt.fromJSON = function(value, parsers = { [typeName]: adt }, keysIndicateType = false) {
     const valueTypeName = value[typeJsonKey];
     const valueTagName = value[tagJsonKey];
     const valueContents = value[valueJsonKey];
-
     assertType(typeName, valueTypeName);
-    const parsedValue = mapValues(valueContents, parseValue(parsers));
+    const parsersByType = keysIndicateType ? parsers
+          : /*otherwise*/                    indexByType(values(parsers));
+
+    const parsedValue = mapValues(valueContents, parseValue(parsersByType));
     return Object.assign(Object.create(adt[valueTagName].prototype), parsedValue);
   };
 };
+

--- a/src/core/adt/serialize.js
+++ b/src/core/adt/serialize.js
@@ -1,0 +1,32 @@
+const { tagSymbol, typeSymbol } = require('./core');
+const mapValues = require('folktale/core/object/map-values');
+
+const assertType = (given, expected) => {
+  if (expected !== given) {
+    throw new TypeError(`
+       The JSON structure was generated from ${expected}.
+       You are trying to serialize it into ${given}. 
+    `);
+  }
+};
+const parseValue = (parsers) => (value) =>
+  parsers[value.typeName] ? parsers[value.typeName].fromJSON(value, parsers)
+  : /* else */              value;
+
+const serializeValue = (value) =>
+  typeof value.toJSON === 'function' ? value.toJSON() : value;
+
+module.exports = (variant, adt) => {
+  const typeName = adt[typeSymbol];
+  const tagName = variant.prototype[tagSymbol];
+
+  variant.prototype.toJSON = function() {
+    return { typeName, tagName, value: mapValues(this, serializeValue) };
+  };
+
+  adt.fromJSON = function(value, parsers = { [typeName]: adt }) {
+    assertType(typeName, value.typeName);
+    const parsedValue = mapValues(value.value, parseValue(parsers));
+    return Object.assign(Object.create(adt[value.tagName].prototype), parsedValue);
+  };
+};

--- a/test/core.adt.es6
+++ b/test/core.adt.es6
@@ -68,12 +68,12 @@ describe('Data.ADT.derive', function() {
     })
   });
   describe('Serialize', function() {
-    const AB = data('AB', {
+    const AB = data('folktale:AB', {
       A: (value) => ({ value }),
       B: (value) => ({ value })
     }).derive(serialize, setoid);
     
-    const CD = data('CD', {
+    const CD = data('folktale:CD', {
       C: (value) => ({value}),
       D: (value) => ({value})
     }).derive(serialize, setoid);

--- a/test/core.adt.es6
+++ b/test/core.adt.es6
@@ -11,7 +11,7 @@
 //----------------------------------------------------------------------
 
 const { property, forall} = require('jsverify');
-const {data, setoid, show} = require('../core/adt/')
+const {data, setoid, show, serialize} = require('../core/adt/')
 
 describe('Data.ADT.derive', function() {
   describe('Setoid', function() {
@@ -51,7 +51,6 @@ describe('Data.ADT.derive', function() {
     }).derive(show)
 
     property('Types have a string representation', function() {
-      debugger
       return AB.toString()  === 'AB';
     })
 
@@ -66,6 +65,31 @@ describe('Data.ADT.derive', function() {
     })
     property('Recursive Values have a string representation', function() {
       return AB.A({rec:AB.A(1)}).toString()  ===  'AB.A({ value: { rec: AB.A({ value: 1 }) } })'
+    })
+  });
+  describe('Serialize', function() {
+    const AB = data('AB', {
+      A: (value) => ({ value }),
+      B: (value) => ({ value })
+    }).derive(serialize, setoid);
+    
+    const CD = data('CD', {
+      C: (value) => ({value}),
+      D: (value) => ({value})
+    }).derive(serialize, setoid);
+
+    const {A, B} = AB;
+    const {C, D} = CD;
+
+    property('Serializing a value and deserializing it yields a similar value', 'json', function(a) {
+      return AB.fromJSON(A(a).toJSON()).equals(A(a))
+    })
+    property('Serializing a *recursive* value and deserializing it yields a similar value', 'json', function(a) {
+      return AB.fromJSON(A(B(a)).toJSON()).equals(A(B(a)))
+    })
+
+    property('Serializing a *composite* value and deserializing it yields a similar value (when the proper parsers are provided).', 'json', function(a) {
+      return AB.fromJSON(A(B(C(a))).toJSON(), {AB, CD}).equals(A(B(C(a))))
     })
   });
 });


### PR DESCRIPTION
This `serialize` derivation adds a `toJSON` method to the instance prototype and a static `fromJSON` function to the ADT constructor. 

`fromJSON` does not use the variant constructors but rather it assumes the listed fields are correct and just copies them.

The methods work recursively: `toJSON` looks for `toJSON` method on each value and leaves it as it is if it does not have one.  `fromJSON` acceps as a second argument an object containing ADT definitions that applies them if the types match. 

Looking forward to hearing your thoughts on this.