### PR TITLE
Validation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "origamitower"
+  "extends": "origamitower",
+
+  "rules": {
+      "linebreak-style": ["warn", "windows"]
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,3 @@
 {
-  "extends": "origamitower",
-
-  "rules": {
-      "linebreak-style": ["warn", "windows"]
-  }
+  "extends": "origamitower"
 }

--- a/src/data/either/core.js
+++ b/src/data/either/core.js
@@ -61,7 +61,7 @@ Right.prototype[fl.chain] = function(transformation) {
 
 // NOTE:
 // `get` is similar to Comonad's `extract`. The reason we don't implement
-// Comonad here is that `get` is partial, and not defined for Nothing
+// Comonad here is that `get` is partial, and not defined for Left
 // values.
 
 Left.prototype.get = function() {

--- a/src/data/either/core.js
+++ b/src/data/either/core.js
@@ -1,4 +1,5 @@
-const assertType = require('../../helpers/assertType');
+const assertType = require('folktale/helpers/assertType');
+const assertFunction = require('folktale/helpers/assertFunction');
 const { data, setoid, show } = require('folktale/core/adt/');
 const fl   = require('fantasy-land');
 
@@ -8,12 +9,6 @@ const Either = data('folktale:Data.Either', {
 }).derive(setoid, show);
 
 const { Left, Right } = Either;
-
-const assertFunction = (method, transformation) => {
-  if (typeof transformation !== 'function') {
-    throw new TypeError(`${method} expects a function, but was given ${transformation}.`);
-  }
-};
 
 const assertEither = assertType(Either);
 

--- a/src/data/validation/core.js
+++ b/src/data/validation/core.js
@@ -1,0 +1,128 @@
+const assertType = require('folktale/helpers/assertType');
+const assertFunction = require('folktale/helpers/assertFunction');
+const { data, setoid, show } = require('folktale/core/adt/');
+const fl   = require('fantasy-land');
+
+const Validation = data('folktale:Data.Validation', {
+  Success(value) { return { value } },
+  Failure(value) { return { value } }
+}).derive(setoid, show);
+
+const { Success, Failure } = Validation;
+
+const assertValidation = assertType(Validation);
+
+// -- Functor ----------------------------------------------------------
+Success.prototype[fl.map] = function(transformation) {
+  assertFunction('Validation.Success#map', transformation);
+  return Success(transformation(this.value));
+};
+Failure.prototype[fl.map] = function(transformation) {
+  assertFunction('Validation.Failure#map', transformation);
+  return this;
+};
+
+// -- Apply ------------------------------------------------------------
+Success.prototype[fl.ap]  = function(aValidation) {
+  assertValidation('Success#ap', aValidation);
+  return Failure.hasInstance(aValidation) ? aValidation
+  :      /* otherwise */                    aValidation.map(this.value);
+};
+
+Failure.prototype[fl.ap]  = function(aValidation) {
+  assertValidation('Failure#ap', aValidation);
+  return Failure.hasInstance(aValidation) ? Failure(this.value.concat(aValidation.value))
+  :      /* otherwise */                    aValidation.map(this.value);
+};
+
+// -- Applicative ------------------------------------------------------
+Validation[fl.of] = Success;
+
+// -- Extracting values and recovering ---------------------------------
+
+// NOTE:
+// `get` is similar to Comonad's `extract`. The reason we don't implement
+// Comonad here is that `get` is partial, and not defined for Failure
+// values.
+
+Success.prototype.get = function() {
+  return this.value;
+};
+
+Failure.prototype.get = function() {
+  throw new TypeError(`Can't extract the value of a Failure.
+
+Failure does not contain a normal value - it contains an error.
+You might consider switching from Validation#get to Validation#getOrElse, or some other method
+that is not partial.
+  `);
+};
+
+
+Success.prototype.getOrElse = function(_default_) {
+  return this.value;
+};
+
+Failure.prototype.getOrElse = function(default_) {
+  return default_;
+};
+
+Success.prototype.orElse = function(_) {
+  return this;
+};
+
+Failure.prototype.orElse = function(handler) {
+  return handler(this.value);
+};
+
+
+// -- Folds and extended transformations--------------------------------
+
+Validation.fold = function(f, g) {
+  return this.cata({
+    Success: ({ value }) => f(value),
+    Failure: ({ value }) => g(value)
+  });
+};
+
+Validation.merge = function() {
+  return this.value;
+};
+
+Validation.swap = function() {
+  return this.fold(Failure, Success);
+};
+
+Validation.bimap = function(f, g) {
+  return this.cata({
+    Success: ({ value }) => Success(f(value)),
+    Failure: ({ value }) => Failure(g(value))
+  });
+};
+
+Success.prototype.failureMap = function(transformation) {
+  assertFunction('Validation.Success#failureMap', transformation);
+  return this;
+};
+Failure.prototype.failureMap = function(transformation) {
+  assertFunction('Validation.Failure#failureMap', transformation);
+  return Failure(transformation(this.value));
+};
+
+
+// -- JSON conversions -------------------------------------------------
+Success.prototype.toJSON = function() {
+  return {
+    '#type': 'folktale:Validation.Success',
+    value:   this.value
+  };
+};
+
+Failure.prototype.toJSON = function() {
+  return {
+    '#type': 'folktale:Validation.Failure',
+    value:   this.value
+  };
+};
+
+module.exports = Validation;

--- a/src/data/validation/core.js
+++ b/src/data/validation/core.js
@@ -2,6 +2,7 @@ const assertType = require('folktale/helpers/assertType');
 const assertFunction = require('folktale/helpers/assertFunction');
 const { data, setoid, show } = require('folktale/core/adt/');
 const fl   = require('fantasy-land');
+const constant = require('folktale/core/lambda/constant');
 
 const Validation = data('folktale:Data.Validation', {
   Success(value) { return { value } },
@@ -58,7 +59,7 @@ that is not partial.
   `);
 };
 
-// -- Semigroup -------------------------------------------------------
+// -- Semigroup --------------------------------------------------------
 Validation[fl.concat] = function(aValidation) {
   assertValidation('Validation#concat', aValidation);
   return this.cata({
@@ -68,6 +69,9 @@ Validation[fl.concat] = function(aValidation) {
   });
 };
 
+
+// -- Monoid -----------------------------------------------------------
+Validation[fl.empty] = constant(Success(x => x));
 
 Success.prototype.getOrElse = function(_default_) {
   return this.value;

--- a/src/data/validation/core.js
+++ b/src/data/validation/core.js
@@ -58,6 +58,16 @@ that is not partial.
   `);
 };
 
+// -- Semigroup -------------------------------------------------------
+Validation[fl.concat] = function(aValidation) {
+  assertValidation('Validation#concat', aValidation);
+  return this.cata({
+    Success: (_) => aValidation,
+    Failure: ({ value }) => Failure.hasInstance(aValidation) ? Failure(value.concat(aValidation.value))
+                            :     /* otherwise */              this
+  });
+};
+
 
 Success.prototype.getOrElse = function(_default_) {
   return this.value;

--- a/src/data/validation/core.js
+++ b/src/data/validation/core.js
@@ -66,12 +66,16 @@ Validation[fl.concat] = function(aValidation) {
   return this.cata({
     Failure: ({ value }) => Failure.hasInstance(aValidation) ? Failure(value.concat(aValidation.value))
                             :     /* otherwise */              this,
-    Success: (_) => aValidation.equals(aValidation.empty()) ? this : aValidation
+    Success: (_) => aValidation
   });
 };
 
-// -- Monoid -----------------------------------------------------------
-Validation[fl.empty] = constant(Success(x => x));
+// -- Extracting values and recovering ---------------------------------
+
+// NOTE:
+// `get` is similar to Comonad's `extract`. The reason we don't implement
+// Comonad here is that `get` is partial, and not defined for Left
+// values.
 
 Failure.prototype.getOrElse = function(default_) {
   return default_;

--- a/src/data/validation/fromNullable.js
+++ b/src/data/validation/fromNullable.js
@@ -1,0 +1,5 @@
+const { Success, Failure } = require('./core');
+
+module.exports = (a) =>
+  a != null ? Success(a)
+  :/*else*/   Failure(a);

--- a/src/data/validation/index.js
+++ b/src/data/validation/index.js
@@ -11,8 +11,6 @@
 //----------------------------------------------------------------------
 
 module.exports = {
-  maybe: require('./maybe'),
-  either: require('./either'),
-  validation: require('./validation')
+  ...require('./core'),
+  fromNullable: require('./fromNullable')
 };
-

--- a/src/helpers/assertFunction.js
+++ b/src/helpers/assertFunction.js
@@ -1,0 +1,5 @@
+module.exports = (method, transformation) => {
+  if (typeof transformation !== 'function') {
+    throw new TypeError(`${method} expects a function, but was given ${transformation}.`);
+  }
+};

--- a/test/core.adt.es6
+++ b/test/core.adt.es6
@@ -51,7 +51,6 @@ describe('Data.ADT.derive', function() {
     }).derive(show)
 
     property('Types have a string representation', function() {
-      debugger
       return AB.toString()  === 'AB';
     })
 

--- a/test/data.validation.es6
+++ b/test/data.validation.es6
@@ -71,17 +71,6 @@ describe('Data.Validation', function() {
       return _.Success(a).concat(_.Failure(b)).equals(_.Failure(b))
     });
   })
-  describe('Monoid', function () {
-    property('Failure#empty', 'string', 'string', function(a, b) {
-      return _.empty().concat(_.Failure(a)).equals(_.Failure(a).concat(_.empty())) && _.Failure(a).concat(_.empty()).equals(_.Failure(a))
-    });
-    property('Success#empty' , 'string', 'string', function(a, b) {
-      return _.empty().concat(_.Success(a)).equals(_.Success(a).concat(_.empty())) && _.Success(a).concat(_.empty()).equals(_.Success(a))
-    });
-    property('Validation#empty/Validation#concat' , 'string', 'string', function(a, b) {
-      return [_.Failure(a), _.Failure(b)].reduce((a, b) => a.concat(b), _.empty()).equals(_.Failure(a.concat(b)))
-    });
-  });
 
   describe('extracting/recovering', function () {
     property('Failure#getOrElse', 'json', 'json', function(a, b) {

--- a/test/data.validation.es6
+++ b/test/data.validation.es6
@@ -60,6 +60,18 @@ describe('Data.Validation', function() {
     });
   });
 
+  describe('Semigroup', function () {
+    property('Failure#concat', 'string', 'string', function(a, b, f) {
+      return _.Failure(a).concat(_.Failure(b)).equals(_.Failure(a.concat(b)))
+    });
+    property('Success#concat', 'string', 'string', function(a, b, f) {
+      return _.Success(a).concat(_.Success(b)).equals(_.Success(b))
+    });
+    property('Success/Failure#concat', 'string', 'string', function(a, b, f) {
+      return _.Success(a).concat(_.Failure(b)).equals(_.Failure(b))
+    });
+  })
+
   describe('extracting/recovering', function () {
     property('Failure#getOrElse', 'json', 'json', function(a, b) {
       return _.Failure(b).getOrElse(a) === a

--- a/test/data.validation.es6
+++ b/test/data.validation.es6
@@ -41,20 +41,19 @@ describe('Data.Validation', function() {
       return (a === b) === (_.of(a).equals(_.of(b)))
     });
     property('Success#ap', 'string', 'string', 'string -> string -> string', function(a, b, f) {
-      debugger
       return _.Success(f)
                 .ap(_.Success(a))
                 .ap(_.Success(b))
                 .equals(_.Success(f(a)(b)))
     });
     property('Success/Failure#ap', 'string', 'string','string -> string -> string', function(a, b, f) {
-      return _.Success((a) => (b) => f(a,b))
+      return _.Success(f)
                 .ap(_.Success(a))
                 .ap(_.Failure(b))
                 .equals(_.Failure(b))
     });
     property('Failure#ap', 'string', 'string','string -> string -> string', function(a, b, f) {
-      return _.Success((a) => (b) => f(a,b))
+      return _.Success(f)
                 .ap(_.Failure(a))
                 .ap(_.Failure(b))
                 .equals(_.Failure(a.concat(b)))

--- a/test/data.validation.es6
+++ b/test/data.validation.es6
@@ -72,10 +72,13 @@ describe('Data.Validation', function() {
     });
   })
   describe('Monoid', function () {
-    property('Validation#empty', 'string', 'string', function(a, b) {
-      return _.empty().concat(_.Failure(a)).equals(_.Failure(a))
+    property('Failure#empty', 'string', 'string', function(a, b) {
+      return _.empty().concat(_.Failure(a)).equals(_.Failure(a).concat(_.empty())) && _.Failure(a).concat(_.empty()).equals(_.Failure(a))
     });
-    property('Validation#empty and Validation#concat' , 'string', 'string', function(a, b) {
+    property('Success#empty' , 'string', 'string', function(a, b) {
+      return _.empty().concat(_.Success(a)).equals(_.Success(a).concat(_.empty())) && _.Success(a).concat(_.empty()).equals(_.Success(a))
+    });
+    property('Validation#empty/Validation#concat' , 'string', 'string', function(a, b) {
       return [_.Failure(a), _.Failure(b)].reduce((a, b) => a.concat(b), _.empty()).equals(_.Failure(a.concat(b)))
     });
   });
@@ -98,10 +101,10 @@ describe('Data.Validation', function() {
   describe('folds', function () {
     const id = (a) => a
     property('Failure#fold', 'json', 'json -> json', function(a, f) {
-      return _.Success(a).fold(f, id) === f(a)
+      return _.Success(a).fold(id, f) === f(a)
     });
     property('Success#fold', 'json', 'json -> json', function(a, f) {
-      return _.Failure(a).fold(id, f) === f(a)
+      return _.Failure(a).fold(f, id) === f(a)
     });
 
     property('Failure#merge', 'json', function(a) {
@@ -119,10 +122,10 @@ describe('Data.Validation', function() {
     });
 
     property('Success#bimap', 'json', 'json -> json', function(a, f) {
-      return _.Success(a).bimap(f, id).equals(_.Success(f(a)))
+      return _.Success(a).bimap(id, f).equals(_.Success(f(a)))
     });
     property('Failure#bimap', 'json', 'json -> json', function(a, f) {
-      return _.Failure(a).bimap(id, f).equals(_.Failure(f(a)))
+      return _.Failure(a).bimap(f, id).equals(_.Failure(f(a)))
     });
 
     property('Failure#failureMap', 'json', 'json -> json', function(a, f) {

--- a/test/data.validation.es6
+++ b/test/data.validation.es6
@@ -61,16 +61,24 @@ describe('Data.Validation', function() {
   });
 
   describe('Semigroup', function () {
-    property('Failure#concat', 'string', 'string', function(a, b, f) {
+    property('Failure#concat', 'string', 'string', function(a, b) {
       return _.Failure(a).concat(_.Failure(b)).equals(_.Failure(a.concat(b)))
     });
-    property('Success#concat', 'string', 'string', function(a, b, f) {
+    property('Success#concat', 'string', 'string', function(a, b) {
       return _.Success(a).concat(_.Success(b)).equals(_.Success(b))
     });
     property('Success/Failure#concat', 'string', 'string', function(a, b, f) {
       return _.Success(a).concat(_.Failure(b)).equals(_.Failure(b))
     });
   })
+  describe('Monoid', function () {
+    property('Validation#empty', 'string', 'string', function(a, b) {
+      return _.empty().concat(_.Failure(a)).equals(_.Failure(a))
+    });
+    property('Validation#empty and Validation#concat' , 'string', 'string', function(a, b) {
+      return [_.Failure(a), _.Failure(b)].reduce((a, b) => a.concat(b), _.empty()).equals(_.Failure(a.concat(b)))
+    });
+  });
 
   describe('extracting/recovering', function () {
     property('Failure#getOrElse', 'json', 'json', function(a, b) {

--- a/test/data.validation.es6
+++ b/test/data.validation.es6
@@ -1,0 +1,117 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// Copyright (C) 2015-2016 Quildreen Motta.
+// Licensed under the MIT licence.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const { property, forall} = require('jsverify');
+const _ = require('../').data.validation;
+
+describe('Data.Validation', function() {
+
+  describe('constructors', function () {
+    property('fromNullable#Failure', function() {
+        return _.fromNullable(null).equals(_.Failure(null))
+    });
+
+    property('fromNullable#Success', 'json', function(a) {
+        return _.fromNullable(a).equals(_.Success(a))
+    }); 
+  });
+
+  describe('Functor', function () {
+    property('map', 'json', 'json -> json', function(a, f) {
+      return _.of(f(a)).equals(_.of(a).map(f))
+    });
+    
+    property('Failure#map', 'json', 'json -> json', function(a, f) {
+      return _.Failure(a).map(f).equals(_.Failure(a))
+    });
+  });
+
+  describe('Applicative', function () {
+
+    property('of', 'json', 'json', function(a, b) {
+      return (a === b) === (_.of(a).equals(_.of(b)))
+    });
+    property('Success#ap', 'string', 'string', 'string -> string -> string', function(a, b, f) {
+      debugger
+      return _.Success(f)
+                .ap(_.Success(a))
+                .ap(_.Success(b))
+                .equals(_.Success(f(a)(b)))
+    });
+    property('Success/Failure#ap', 'string', 'string','string -> string -> string', function(a, b, f) {
+      return _.Success((a) => (b) => f(a,b))
+                .ap(_.Success(a))
+                .ap(_.Failure(b))
+                .equals(_.Failure(b))
+    });
+    property('Failure#ap', 'string', 'string','string -> string -> string', function(a, b, f) {
+      return _.Success((a) => (b) => f(a,b))
+                .ap(_.Failure(a))
+                .ap(_.Failure(b))
+                .equals(_.Failure(a.concat(b)))
+    });
+  });
+
+  describe('extracting/recovering', function () {
+    property('Failure#getOrElse', 'json', 'json', function(a, b) {
+      return _.Failure(b).getOrElse(a) === a
+    });
+    property('Success#getOrElse', 'json', 'json', function(a, b) {
+      return _.Success(b).getOrElse(a) === b
+    });
+
+    property('Failure#orElse', 'json', 'json', function(a, b) {
+      return _.Failure(b).orElse(() => a) === a
+    });
+    property('Success#orElse', 'json', 'json', function(a, b) {
+      return _.Success(b).orElse(() => b).equals(_.Success(b))
+    });
+  });
+  describe('folds', function () {
+    const id = (a) => a
+    property('Failure#fold', 'json', 'json -> json', function(a, f) {
+      return _.Success(a).fold(f, id) === f(a)
+    });
+    property('Success#fold', 'json', 'json -> json', function(a, f) {
+      return _.Failure(a).fold(id, f) === f(a)
+    });
+
+    property('Failure#merge', 'json', function(a) {
+      return _.Success(a).merge() === a 
+    });
+    property('Success#merge', 'json', function(a) {
+      return _.Failure(a).merge() === a 
+    });
+
+    property('Failure#swap', 'json', function(a) {
+      return _.Failure(a).swap().equals(_.Success(a))
+    });
+    property('Success#swap', 'json', function(a) {
+      return _.Success(a).swap().equals(_.Failure(a))
+    });
+
+    property('Success#bimap', 'json', 'json -> json', function(a, f) {
+      return _.Success(a).bimap(f, id).equals(_.Success(f(a)))
+    });
+    property('Failure#bimap', 'json', 'json -> json', function(a, f) {
+      return _.Failure(a).bimap(id, f).equals(_.Failure(f(a)))
+    });
+
+    property('Failure#failureMap', 'json', 'json -> json', function(a, f) {
+      return _.Failure(f(a)).equals(_.Failure(a).failureMap(f))
+    });
+    
+    property('Success#failureMap', 'json', 'json -> json', function(a, f) {
+      return _.Success(a).failureMap(f).equals(_.Success(a))
+    });
+  });
+});


### PR DESCRIPTION
Done except the functions for converting it to `Either` and (I think also good to have) `Maybe`.

Suggestion: instead of having `fromEither` function, isn't it better if we have `toValidation` method on the Either datatype (and vise-versa). This way you woudn't have to include a module in order to do the conversion, and also seems to me more correct in therms of design.

Looking forward for input on that. 
Also what did you have in mind for the Conversions module in https://github.com/origamitower/folktale/issues/5?
