### PR TITLE
Replace `npmignore` with whitelist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-.tern-port
-*.orig

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 - Brett (https://github.com/bberry6)
 - Kris Reeves (https://github.com/myndzi)
 - Tenor Biel (https://github.com/L8D)
+- Juan Soto (https://github.com/sotojuan)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
     "folktale",
     "monads"
   ],
+  "files": [
+    "core/",
+    "data/",
+    "helpers/",
+    "index.js"
+  ],
   "author": "Quildreen Motta",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "core/",
     "data/",
     "helpers/",
+    "documentation.js",
     "index.js"
   ],
   "author": "Quildreen Motta",


### PR DESCRIPTION
Fixes #32. I looked at the `Makefile` to make sure I wasn't missing anything—essentially this change says "include only  what is in this array when publishing to npm".

Some files are always included and don't need to be specified, and some are always ignored. See [here](https://docs.npmjs.com/files/package.json#files) for more info.

If I missed anything, let me know!