### PR TITLE
Refactor for some fantasy-land stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "url": "https://github.com/origamitower/folktale/issues"
   },
   "dependencies": {
-    "fantasy-land": "^0.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/src/core/adt/setoid.js
+++ b/src/core/adt/setoid.js
@@ -354,7 +354,7 @@ const createDerivation = (valuesEqual) => {
     const leftSetoid  = isSetoid(a);
     const rightSetoid = isSetoid(b);
     if (leftSetoid) {
-      if (rightSetoid)  return flEquals(a, b);
+      if (rightSetoid)  return flEquals(b, a);
       else              return false;
     }
 

--- a/src/core/adt/setoid.js
+++ b/src/core/adt/setoid.js
@@ -9,7 +9,7 @@
 
 // --[ Dependencies ]---------------------------------------------------
 const assertType = require('folktale/helpers/assertType');
-const { equals } = require('folktale/core/fantasy-land');
+const { equals:flEquals } = require('folktale/core/fantasy-land');
 const fl = require('folktale/helpers/fantasy-land');
 const provideAliases = require('folktale/helpers/provide-fantasy-land-aliases');
 const { tagSymbol, typeSymbol } = require('./core');
@@ -354,7 +354,7 @@ const createDerivation = (valuesEqual) => {
     const leftSetoid  = isSetoid(a);
     const rightSetoid = isSetoid(b);
     if (leftSetoid) {
-      if (rightSetoid)  return equals(a, b);
+      if (rightSetoid)  return flEquals(a, b);
       else              return false;
     }
 

--- a/src/core/fantasy-land/core/ap.js
+++ b/src/core/fantasy-land/core/ap.js
@@ -12,6 +12,6 @@ const warn = require('folktale/helpers/warn-deprecated')('ap');
 const unsupported = require('folktale/helpers/unsupported-method')('ap');
 
 module.exports = (a, b) =>
-  typeof a[ap] === 'function' ?  a[ap](b)
+  typeof a[ap] === 'function' ?  b[ap](a)
 : typeof a.ap  === 'function' ?  warn(a.ap(b))
 : /*otherwise*/                  unsupported(a);

--- a/src/data/either/core.js
+++ b/src/data/either/core.js
@@ -1,7 +1,7 @@
 const assertType = require('folktale/helpers/assertType');
 const assertFunction = require('folktale/helpers/assertFunction');
 const { data, setoid, show } = require('folktale/core/adt/');
-const fl   = require('fantasy-land');
+const provideAliases = require('folktale/helpers/provide-fantasy-land-aliases');
 
 const Either = data('folktale:Data.Either', {
   Left(value)  { return { value } },
@@ -13,38 +13,38 @@ const { Left, Right } = Either;
 const assertEither = assertType(Either);
 
 // -- Functor ----------------------------------------------------------
-Left.prototype[fl.map] = function(transformation) {
+Left.prototype.map = function(transformation) {
   assertFunction('Either.Left#map', transformation);
   return this;
 };
 
-Right.prototype[fl.map] = function(transformation) {
+Right.prototype.map = function(transformation) {
   assertFunction('Either.Right#map', transformation);
   return Right(transformation(this.value));
 };
 
 // -- Apply ------------------------------------------------------------
-Left.prototype[fl.ap] = function(anEither) {
-  assertEither('Left#ap', anEither);
+Left.prototype.apply = function(anEither) {
+  assertEither('Left#apply', anEither);
   return this;
 };
 
-Right.prototype[fl.ap] = function(anEither) {
-  assertEither('Right#ap', anEither);
+Right.prototype.apply = function(anEither) {
+  assertEither('Right#apply', anEither);
   return anEither.map(this.value);
 };
 
 
 // -- Applicative ------------------------------------------------------
-Either[fl.of] = Right;
+Either.of = Right;
 
 // -- Chain ------------------------------------------------------------
-Left.prototype[fl.chain] = function(transformation) {
+Left.prototype.chain = function(transformation) {
   assertFunction('Either.Left#chain', transformation);
   return this;
 };
 
-Right.prototype[fl.chain] = function(transformation) {
+Right.prototype.chain = function(transformation) {
   assertFunction('Either.Right#chain', transformation);
   return transformation(this.value);
 };
@@ -144,5 +144,9 @@ Either.toValidation = function(...args) {
 Either.toMaybe = function(...args) {
   return require('folktale/data/conversions/either-to-maybe')(this, ...args);
 };
+
+provideAliases(Left.prototype);
+provideAliases(Right.prototype);
+provideAliases(Either);
 
 module.exports = Either;

--- a/src/data/maybe/core.js
+++ b/src/data/maybe/core.js
@@ -38,12 +38,12 @@ Just.prototype.map = function(transformation) {
 
 // -- Apply ------------------------------------------------------------
 Nothing.prototype.apply = function(aMaybe) {
-  assertMaybe('Maybe.Nothing#ap', aMaybe);
+  assertMaybe('Maybe.Nothing#apply', aMaybe);
   return this;
 };
 
 Just.prototype.apply = function(aMaybe) {
-  assertMaybe('Maybe.Just#ap', aMaybe);
+  assertMaybe('Maybe.Just#apply', aMaybe);
   return aMaybe.map(this.value);
 };
 

--- a/src/data/validation/core.js
+++ b/src/data/validation/core.js
@@ -1,7 +1,7 @@
 const assertType = require('folktale/helpers/assertType');
 const assertFunction = require('folktale/helpers/assertFunction');
 const { data, setoid, show } = require('folktale/core/adt/');
-const fl   = require('fantasy-land');
+const provideAliases = require('folktale/helpers/provide-fantasy-land-aliases');
 const constant = require('folktale/core/lambda/constant');
 
 const Validation = data('folktale:Data.Validation', {
@@ -14,30 +14,30 @@ const { Success, Failure } = Validation;
 const assertValidation = assertType(Validation);
 
 // -- Functor ----------------------------------------------------------
-Failure.prototype[fl.map] = function(transformation) {
+Failure.prototype.map = function(transformation) {
   assertFunction('Validation.Failure#map', transformation);
   return this;
 };
-Success.prototype[fl.map] = function(transformation) {
+Success.prototype.map = function(transformation) {
   assertFunction('Validation.Success#map', transformation);
   return Success(transformation(this.value));
 };
 
 // -- Apply ------------------------------------------------------------
-Failure.prototype[fl.ap]  = function(aValidation) {
-  assertValidation('Failure#ap', aValidation);
+Failure.prototype.apply = function(aValidation) {
+  assertValidation('Failure#apply', aValidation);
   return Failure.hasInstance(aValidation) ? Failure(this.value.concat(aValidation.value))
   :      /* otherwise */                    this;
 };
 
-Success.prototype[fl.ap]  = function(aValidation) {
-  assertValidation('Success#ap', aValidation);
+Success.prototype.apply = function(aValidation) {
+  assertValidation('Success#apply', aValidation);
   return Failure.hasInstance(aValidation) ? aValidation
   :      /* otherwise */                    aValidation.map(this.value);
 };
 
 // -- Applicative ------------------------------------------------------
-Validation[fl.of] = Success;
+Validation.of = Success;
 
 // -- Extracting values and recovering ---------------------------------
 
@@ -61,7 +61,7 @@ Success.prototype.get = function() {
 
 
 // -- Semigroup --------------------------------------------------------
-Validation[fl.concat] = function(aValidation) {
+Validation.concat = function(aValidation) {
   assertValidation('Validation#concat', aValidation);
   return this.matchWith({
     Failure: ({ value }) => Failure.hasInstance(aValidation) ? Failure(value.concat(aValidation.value))
@@ -148,5 +148,10 @@ Validation.toEither = function(...args) {
 Validation.toMaybe = function(...args) {
   return require('folktale/data/conversions/validation-to-maybe')(this, ...args);
 };
+
+
+provideAliases(Success.prototype);
+provideAliases(Failure.prototype);
+provideAliases(Validation);
 
 module.exports = Validation;

--- a/src/helpers/provide-fantasy-land-aliases.js
+++ b/src/helpers/provide-fantasy-land-aliases.js
@@ -1,0 +1,260 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+
+const aliases = {
+  equals: {
+    /*
+     * Fantasy Land's Setoid `equals'.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   ('S 'a).('S 'a) => Boolean
+     *   where 'S is Setoid
+     */
+    'fantasy-land/equals'(that) {
+      return this.equals(that);
+    }
+  },
+
+  concat: {
+    /*
+     * Fantasy Land's Semigroup `concat`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   ('S 'a).('S 'a) => 'S 'a
+     *   where 'S is Semigroup
+     */
+    'fantasy-land/concat'(that) {
+      return this.concat(that);
+    }
+  },
+
+  empty: {
+    /*
+     * Fnatasy Land's Monoid `empty`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   ('M).() => 'M a
+     *   where 'M is Monoid
+     */
+    'fantasy-land/empty'() {
+      return this.empty();
+    }
+  },
+
+  map: {
+    /*
+     * Fantasy Land's Functor `map`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   ('F 'a).(('a) => 'b) => 'F 'b
+     *   where 'F is Functor
+     */
+    'fantasy-land/map'(transformation) {
+      return this.map(transformation);
+    }
+  },
+
+  apply: {
+    /*
+     * Fantasy Land's Apply `ap`
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   ('F ('a) => b).('F 'a) => 'F 'b
+     *   where 'F is Apply
+     */
+    ap(that) {
+      return this.apply(that);
+    },
+
+    /*
+     * Fantasy Land's Apply `ap`
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   ('F 'a).('F ('a) => 'b) => 'F 'b
+     *   where 'F is Apply
+     */
+    'fantasy-land/ap'(that) {
+      return that.apply(this);
+    }
+  },
+
+  of: {
+    /*
+     * Fantasy Land's Applicative `of`
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall F, a:
+     *     (F).(a) => F a
+     *   where F is Applicative 
+     */
+    'fantasy-land/of'(value) {
+      return this.of(value);
+    }
+  },
+
+  reduce: {
+    /*
+     * Fantasy Land’s Foldable `reduce`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall F, a, b:
+     *     (F a).((b, a) => b, b) => b
+     *   where F is Foldable  
+     */
+    'fantasy-land/reduce'(combinator, initial) {
+      return this.reduce(combinator, initial);
+    }
+  },
+
+  traverse: {
+    /*
+     * Fantasy Land’s Traversable `traverse`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall F, T, a, b:
+     *     (T a).((a) => F b, (c) => F c) => F (T b)
+     *   where F is Apply, T is Traversable
+     */
+    'fantasy-land/traverse'(transformation, lift) {
+      return this.traverse(transformation, lift);
+    }
+  },
+
+  chain: {
+    /*
+     * Fantasy Land’s Chain `chain`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall M, a, b:
+     *     (M a).((a) => M b) => M b
+     *   where M is Chain
+     */
+    'fantasy-land/chain'(transformation) {
+      return this.chain(transformation);
+    }
+  },
+
+  chainRecursively: {
+    /*
+     * Fantasy Land’s ChainRec `chainRec`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall M, a, b, c:
+     *     (M).(
+     *       Step:    ((a) => c, (b) => c, a) => M c,
+     *       Initial: a
+     *     ) => M b
+     *   where M is ChainRec 
+     */
+    chainRec(step, initial) {
+      return this.chainRecursively(step, initial);
+    },
+
+    /*
+     * Fantasy Land’s ChainRec `chainRec`.
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall M, a, b, c:
+     *     (M).(
+     *       Step:    ((a) => c, (b) => c, a) => M c,
+     *       Initial: a
+     *     ) => M b
+     *   where M is ChainRec 
+     */
+    'fantasy-land/chainRec'(step, initial) {
+      return this.chainRecursively(step, initial);
+    }
+  },
+
+  extend: {
+    /*
+     * Fantasy Land’s Extend `extend`
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall W, a, b:
+     *     (W a).((W a) => b) => W b
+     *   where W is Extend
+     */
+    'fantasy-land/extend'(transformation) {
+      return this.extend(transformation);
+    }
+  },
+
+  extract: {
+    /*
+     * Fantasy Land’s Comonad `extract`
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall W, a, b:
+     *     (W a).() => a
+     *   where W is Comonad
+     */
+    'fantasy-land/extract'() {
+      return this.extract();
+    }
+  },
+
+  bimap: {
+    /*
+     * Fantasy Land’s Bifunctor `bimap`
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall F, a, b, c, d:
+     *     (F a b).((a) => c, (b) => d) => F c d
+     *   where F is Bifunctor
+     */
+    'fantasy-land/bimap'(f, g) {
+      return this.bimap(f, g);
+    }
+  },
+
+  promap: {
+    /*
+     * Fantasy Land’s Profunctor `promap`
+     * ---
+     * category: Fantasy Land
+     * type: |
+     *   forall P, a, b, c, d:
+     *     (P a b).((c) => a, (b) => d) => P c d
+     */
+    'fantasy-land/promap'(f, g) {
+      return this.promap(f, g);
+    }
+  }
+};
+
+
+const provideAliases = (structure) => {
+  Object.keys(aliases).forEach(method => {
+    if (typeof structure[method] === 'function') {
+      Object.keys(aliases[method]).forEach(alias => {
+        structure[alias] = aliases[method][alias];
+      });
+    }
+  });
+};
+
+
+module.exports = provideAliases;


### PR DESCRIPTION
Following the work on #37, and addressing #39, this patch moves the Fantasy Land interface to aliases of the actual methods in Folktale structures. The new `provide-fantasy-land-aliases` module takes care of handling the aliases automatically, so this allows us to diverge our public API from Fantasy Land interfaces as well (avoiding issues like this recent PR https://github.com/fantasyland/fantasy-land/pull/145), as long as we can map it to the interfaces. It also allows us to choose better names (e.g.: `.apply()` instead of `.ap()`).

Closes #39.

