### PR TITLE
Control monad

### DIFF
--- a/src/control/index.js
+++ b/src/control/index.js
@@ -1,0 +1,12 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+module.exports = {
+  monad: require('./monad'),
+};

--- a/src/control/monad/compose.js
+++ b/src/control/monad/compose.js
@@ -1,0 +1,13 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+//
+const curry = require('folktale/core/lambda/curry/')
+module.exports = curry(3, (f, g, a) => {
+  return f(a).chain(g)
+})

--- a/src/control/monad/compose.js
+++ b/src/control/monad/compose.js
@@ -7,7 +7,4 @@
 //
 //----------------------------------------------------------------------
 //
-const curry = require('folktale/core/lambda/curry/')
-module.exports = curry(3, (f, g, a) => {
-  return f(a).chain(g)
-})
+module.exports = (f, g) => (a) => f(a).chain(g);

--- a/src/control/monad/filter-m.js
+++ b/src/control/monad/filter-m.js
@@ -7,17 +7,17 @@
 //
 //----------------------------------------------------------------------
 
-const curry = require('folktale/core/lambda/curry/')
-module.exports = curry(3, (mConstructor, f, listM) => {
-  return listM.reduce((mList, element) => mList.chain((list) =>
-    f(element).chain((include) => {
-      if (include) {
-        list.push(element)
-        return mConstructor.of(list)
-      } else {
-        return mList
-      }
-    }))
-  , mConstructor.of([]))
+const curry = require('folktale/core/lambda/curry/');
 
-})
+module.exports = curry(3, (m, f, list) =>
+  list.reduce((mList, a) => 
+      mList.chain((list) =>
+        f(a).chain((includeA) => {
+          if (includeA) {
+            list.push(a);
+            return m.of(list);
+          } else {
+            return mList;
+          }
+        }))
+  , m.of([])));

--- a/src/control/monad/filter-m.js
+++ b/src/control/monad/filter-m.js
@@ -1,0 +1,23 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const curry = require('folktale/core/lambda/curry/')
+module.exports = curry(3, (mConstructor, f, listM) => {
+  return listM.reduce((mList, element) => mList.chain((list) =>
+    f(element).chain((include) => {
+      if (include) {
+        list.push(element)
+        return mConstructor.of(list)
+      } else {
+        return mList
+      }
+    }))
+  , mConstructor.of([]))
+
+})

--- a/src/control/monad/index.js
+++ b/src/control/monad/index.js
@@ -13,5 +13,7 @@ module.exports = {
   filterM: require('./filter-m'),
   compose: require('./compose'),
   rightCompose: require('./right-compose'),
-  join: require('./join')
+  join: require('./join'),
+  liftM2: require('./lift-m2.js'),
+  liftMN: require('./lift-mn.js')
 };

--- a/src/control/monad/index.js
+++ b/src/control/monad/index.js
@@ -1,0 +1,17 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+module.exports = {
+  sequence: require('./sequence'),
+  mapM: require('./map-m'),
+  filterM: require('./filter-m'),
+  compose: require('./compose'),
+  rightCompose: require('./right-compose'),
+  join: require('./join')
+};

--- a/src/control/monad/join.js
+++ b/src/control/monad/join.js
@@ -1,0 +1,10 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+module.exports = (m) => m.chain((a) => a)

--- a/src/control/monad/lift-m2.js
+++ b/src/control/monad/lift-m2.js
@@ -2,9 +2,12 @@
 //
 // This source file is part of the Folktale project.
 //
+// Copyright (C) 2015-2016 Quildreen Motta.
+// Licensed under the MIT licence.
+//
 // See LICENCE for licence information.
 // See CONTRIBUTORS for the list of contributors to the project.
 //
 //----------------------------------------------------------------------
 
-module.exports = (m) => m.chain((a) => a);
+module.exports = (f) => (ma, mb) => ma.chain((a) => mb.map((b) => f(a, b)));

--- a/src/control/monad/lift-mn.js
+++ b/src/control/monad/lift-mn.js
@@ -2,11 +2,21 @@
 //
 // This source file is part of the Folktale project.
 //
+// Copyright (C) 2015-2016 Quildreen Motta.
+// Licensed under the MIT licence.
+//
 // See LICENCE for licence information.
 // See CONTRIBUTORS for the list of contributors to the project.
 //
 //----------------------------------------------------------------------
 
-const curry = require('folktale/core/lambda/curry/');
 const sequence = require('./sequence');
-module.exports = curry(3, (m, f, list) => sequence(m, list.map(f)));
+
+const noArgsError = () => {
+  throw new Error('Please supply at least one argument.');
+};
+
+module.exports = (f) => (...argsM) => 
+  argsM.length === 0 ? noArgsError()
+ : /* otherwise */     sequence(argsM[0], argsM)
+                         .map((args) => f(...args));

--- a/src/control/monad/map-m.js
+++ b/src/control/monad/map-m.js
@@ -1,0 +1,12 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const curry = require('folktale/core/lambda/curry/')
+const sequence = require('./sequence')
+module.exports = curry(3, (mConstructor, f, listM) => sequence(mConstructor, listM.map(f)))

--- a/src/control/monad/right-compose.js
+++ b/src/control/monad/right-compose.js
@@ -7,6 +7,5 @@
 //
 //----------------------------------------------------------------------
 //
-const compose = require('./compose')
-const curry = require('folktale/core/lambda/curry/')
-module.exports = curry(3, (f, g, a) => compose(g, f, a))
+const compose = require('./compose');
+module.exports = (f, g) => (a) => compose(g, f)(a);

--- a/src/control/monad/right-compose.js
+++ b/src/control/monad/right-compose.js
@@ -1,0 +1,12 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+//
+const compose = require('./compose')
+const curry = require('folktale/core/lambda/curry/')
+module.exports = curry(3, (f, g, a) => compose(g, f, a))

--- a/src/control/monad/sequence.js
+++ b/src/control/monad/sequence.js
@@ -8,12 +8,13 @@
 //----------------------------------------------------------------------
 //
 
-const curry = require('folktale/core/lambda/curry/')
-module.exports = curry(2, (mConstructor, listM) => 
-  listM.reduce((mList, mElement) => 
+const curry = require('folktale/core/lambda/curry/');
+
+module.exports = curry(2, (m, listM) => 
+  listM.reduce((mList, mA) => 
     mList.chain((list) => 
-      mElement.chain((element) => {
-        list.push(element)
-        return mConstructor.of(list)
+      mA.chain((a) => {
+        list.push(a);
+        return m.of(list);
       }))
-  , mConstructor.of([])))
+  , m.of([])));

--- a/src/control/monad/sequence.js
+++ b/src/control/monad/sequence.js
@@ -1,0 +1,19 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+//
+
+const curry = require('folktale/core/lambda/curry/')
+module.exports = curry(2, (mConstructor, listM) => 
+  listM.reduce((mList, mElement) => 
+    mList.chain((list) => 
+      mElement.chain((element) => {
+        list.push(element)
+        return mConstructor.of(list)
+      }))
+  , mConstructor.of([])))

--- a/src/core/adt/setoid.js
+++ b/src/core/adt/setoid.js
@@ -200,8 +200,8 @@ const sameType = (a, b) => a[typeSymbol] === b[typeSymbol]
  *     // This is fine, because all values are either Setoids or primitives
  *     Id(Id(1)).equals(Id(Id(1))); // ==> true
  * 
- *     // This is not fine, because it compares `[1] === [1]`
- *     Id([1]).equals(Id([1]));     // ==> false
+ *     // This is not fine, because it compares `{} === {}`
+ *     Id({}).equals(Id({}));     // ==> false
  * 
  * To handle complex JS values, one must provide their own deep equality
  * function. Folktale does not have a deep equality function yet, but
@@ -340,7 +340,27 @@ const sameType = (a, b) => a[typeSymbol] === b[typeSymbol]
  * type: |
  *   (('a, 'a) => Boolean) => (Variant, ADT) => Void
  */
+ 
+
 const createDerivation = (valuesEqual) => {
+
+  const arrayEquals = (a, b) => {
+    /*~
+     * Tests if two arrays are equal.
+     * ---
+     * type: ([a], [a]) => Boolean
+     */
+    if (a.length !== b.length) {
+      return false
+    }
+    for (let i = 0; i <a.length; i++) {
+      if(!equals(a[i], b[i])) {
+        return false  
+      }
+    }
+    return true
+  }
+
   /*~
    * Tests if two objects are equal.
    * ---
@@ -358,9 +378,18 @@ const createDerivation = (valuesEqual) => {
       else              return false;
     }
 
+    // compare arrays (by comparing their elements)
+    const leftArray  = Array.isArray(a);
+    const rightArray = Array.isArray(b);
+    if(leftArray) {
+      if (rightArray)  return arrayEquals(b, a);
+      else              return false;
+    }
+
     // fall back to the provided equality
     return valuesEqual(a, b);
   };
+
 
 
   /*~

--- a/src/index.js
+++ b/src/index.js
@@ -31,5 +31,6 @@
  */
 module.exports = {
   core: require('./core'),
-  data: require('./data')
+  data: require('./data'),
+  control: require('./control')
 };

--- a/test/specs-src/control.monad.js
+++ b/test/specs-src/control.monad.js
@@ -20,8 +20,8 @@ describe('control.monad', () => {
   property('compose', 'json -> monad json', 'json -> monad json', 'json', env, (f, g, a) => 
     _.compose(f, g)(a).equals(f(a).chain(g))
   )
-  property('rightCompose', 'json -> monad json', 'json -> monad json', 'json', env, (f, g, a) => 
-    _.compose(f, g)(a).equals(g(a).chain(f))
+  property('rightCompose', 'json -> monad json', 'json -> monad json', 'json', env, (f, g, a) =>
+    _.rightCompose(f, g)(a).equals(g(a).chain(f))
   )
   property('sequence', 'json', 'json', 'json', 'monad json', env, (a, b, c, m) =>
     _.sequence(m, [m.of(a), m.of(b), m.of(c)]).equals(m.of([a, b, c]))
@@ -35,5 +35,13 @@ describe('control.monad', () => {
   property('join', 'monad json', env, (ma) => 
     _.join(ma.of(ma)).equals(ma)
   )
+  property('liftM2', 'monad json', 'json -> json -> json', 'json', 'json', env, (m, fCurried, a, b) => {
+    const f = (a, b) => fCurried(a)(b) 
+    return _.liftM2(f)(m.of(a), m.of(b)).equals(m.of(f(a, b)))
+  })
+  property('liftMN', 'monad json', 'json -> json -> json', 'json', 'json', 'json', env, (m, fCurried, a, b, c) => {
+    const f = (a, b) => fCurried(a)(b) 
+    return _.liftMN(f)(m.of(a), m.of(b), m.of(c)).equals(m.of(f(a, b, c)))
+  })
 })
 

--- a/test/specs-src/control.monad.js
+++ b/test/specs-src/control.monad.js
@@ -1,0 +1,39 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// Copyright (C) 2015-2016 Quildreen Motta.
+// Licensed under the MIT licence.
+//
+// See LICENCE for licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const { property, forall} = require('jsverify');
+const assert = require('assert');
+const env = require('./environment');
+const _ = require('../../control/monad');
+
+describe('control.monad', () => {
+
+  property('compose', 'json -> monad json', 'json -> monad json', 'json', env, (f, g, a) => 
+    _.compose(f, g)(a).equals(f(a).chain(g))
+  )
+  property('rightCompose', 'json -> monad json', 'json -> monad json', 'json', env, (f, g, a) => 
+    _.compose(f, g)(a).equals(g(a).chain(f))
+  )
+  property('sequence', 'json', 'json', 'json', 'monad json', env, (a, b, c, m) =>
+    _.sequence(m, [m.of(a), m.of(b), m.of(c)]).equals(m.of([a, b, c]))
+  )
+  property('mapM', 'json', 'json', 'json', 'json -> monad json', 'monad json', env, (a, b, c, f, m) =>
+    _.mapM(m, f, [a, b, c]).equals(f(a).chain((a) => f(b).chain((b) => f(c).chain((c) => m.of([a, b, c])))))
+  )
+  property('filterM', 'json', 'json', 'json', 'json -> bool', 'monad json', env, (a, b, c, f, m) =>
+    _.filterM(m, (a) => m.of(f(a)), [a, b, c]).equals(m.of([a, b, c].filter(f)))
+  )
+  property('join', 'monad json', env, (ma) => 
+    _.join(ma.of(ma)).equals(ma)
+  )
+})
+

--- a/test/specs-src/core.adt.js
+++ b/test/specs-src/core.adt.js
@@ -166,6 +166,9 @@ describe('Core.ADT', () => {
     property('Similar simple values are equal', 'json', (a) => {
       return A(a).equals(A(a))
     });
+    property('Similar array values are equal', 'json', (a, b) => {
+      return A([a, b]).equals(A([a, b]))
+    });
     property('Similar composite values are equal', 'json', (a) => {
       return A(B(a)).equals(A(B(a)))
     });

--- a/test/specs-src/data.either.js
+++ b/test/specs-src/data.either.js
@@ -37,8 +37,8 @@ describe('Data.Either', function() {
   });
 
   describe('Applicative', () => {
-    property('of', 'json', 'json', (a, b) => {
-      return (a === b) === (_.of(a).equals(_.of(b)))
+    property('of', 'json', 'json', (a) => {
+      return _.of(a).equals(_.of(a))
     });
 
     property('apply', 'json', 'json -> json', (a, f) => {

--- a/test/specs-src/data.validation.js
+++ b/test/specs-src/data.validation.js
@@ -27,8 +27,8 @@ describe('Data.Validation', () => {
 
   describe('Applicative', () => {
 
-    property('of', 'json', 'json', (a, b) => {
-      return (a === b) === (_.of(a).equals(_.of(b)))
+    property('of', 'json', 'json', (a) => {
+      return _.of(a).equals(_.of(a))
     });
     property('Success#apply', 'string', 'string', 'string -> string -> string', (a, b, f) => {
       return _.Success(f)


### PR DESCRIPTION
Hello, 

This request contains port to the functions contained in [basic.js](https://github.com/folktale/control.monads/blob/master/lib/basic.js) of the old version of the package.

The pull request contains one more change - I extended the default `equals` function of all data structures, so it compares array values by comparing the individual elements - I felt that if we have functions that output `M[a]`, we must also support comparing these values. The change also makes the test cases much more concise.

One problem that we should think about is the following: I am using `curry` for `sequence`, `mapM`, and `filterM` (so it is consistent with the functions from `core.fantasy-land` but I am not using it for `compose` (so it is consistent with `lambda.compose`), however because of that the functions from the module aren't consisted with one another. So I think that we should make up a rule about when we use curry and when not.  

~~My proposition: the data always comes separate from the other arguments and if there are more than one arguments beside the data, then we use curry for them only. I am proposing this also because it would make it easier to implement inflix functions. So for example the implementation of `fantasy-land.reduce` will be:~~

```
const reduce = (f, acc) => (data) => data.reduce(f, acc)
const makeInflix = (f) => function(...args) {return f.apply(this, args)}
const reduceCurried = curry(2, reduce)
const reduceInflix = makeInflix(reduce)
```

~~I think this would also prevent some wrong usages.~~

_Update:_ Not so good an idea on second thought. But I still think that we need to find a way for the API to be consistent. 

Finally, a couple of notes on the module itself:
1. The `filterM` implementation of the original version was using recursion and was copying the array on every iteration. I changed it to something more akin to the `sequence` implementation.
2. It is a bit counter intuitive that `liftMN` deduces the monad type from the arguments given (relying on a nonempty array) and all other functions don't.
3. I just realized that I should use `core.fantasy-land.chain`  instead of plain `chain`. Will fix that. 

Anyway, I am looking forward to hear your comments.
