### PR TITLE
Generates annotated files only for tests/docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ npm-debug.log
 *.swp
 /dist/
 /docs/build/
+/annotated/

--- a/docs/.babelrc
+++ b/docs/.babelrc
@@ -5,7 +5,7 @@
     "transform-object-rest-spread",
     "transform-assertion-comments",
     ["babel-plugin-module-alias", [
-      { "src": "./", "expose": "folktale" }
+      { "src": "./annotated", "expose": "folktale" }
     ]]
   ]
 }

--- a/documentation.js
+++ b/documentation.js
@@ -9,6 +9,6 @@
 
 var Interface = require('metamagical-interface');
 var Browser   = require('metamagical-repl')(Interface);
-var Folktale  = require('./');
+var Folktale  = require('./annotated');
 
 module.exports = Browser.for(Interface.for(Folktale));

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -12,6 +12,6 @@
     }],
     "transform-assertion-comments",
     ["babel-plugin-module-alias", [
-      { "src": "./", "expose": "folktale" }
+      { "src": "./annotated", "expose": "folktale" }
     ]]]
 }

--- a/test/specs-src/core.object.js
+++ b/test/specs-src/core.object.js
@@ -17,7 +17,7 @@ const uniq = (xs) => [...new Set(xs)];
 
 describe('Core.Object', () => {
   describe('toPairs(o)', () => {
-    property('returns (key, value) pairs in the object', 'json', (a) =>
+    property('returns (key, value) pairs in the object', 'dict nat', (a) =>
       _.toPairs(a).every(([k, v]) => a[k] === v)
     );
 

--- a/test/specs-src/data.result.js
+++ b/test/specs-src/data.result.js
@@ -109,10 +109,11 @@ describe('Data.Result', function() {
   });
   describe('Conversions', () => {
     property('Error#fromNullable', () => {
-      return _.fromNullable(null).equals(_.Error(null));
+      return _.fromNullable(null).equals(_.Error(null))
+      &&     _.fromNullable(undefined).equals(_.Error(undefined));
     });
 
-    property('Ok#fromNullable', 'json', (a) => {
+    property('Ok#fromNullable', 'number | string | bool | dict nat | array nat', (a) => {
       return _.fromNullable(a).equals(_.Ok(a));
     });
     property('Result#fromValidation', 'json', (a) => {

--- a/test/specs-src/data.validation.js
+++ b/test/specs-src/data.validation.js
@@ -140,9 +140,10 @@ describe('Data.Validation', () => {
   describe('Conversions', () => {
     property('Failure#fromNullable', () => {
         return _.fromNullable(null).equals(_.Failure(null))
+        &&     _.fromNullable(undefined).equals(_.Failure(undefined));
     });
 
-    property('Success#fromNullable', 'json', (a) => {
+    property('Success#fromNullable', 'number | string | bool | dict nat | array nat', (a) => {
         return _.fromNullable(a).equals(_.Success(a))
     }); 
     property('Validation#fromResult', 'json', (a) => {


### PR DESCRIPTION
This means that browser bundles won't have metamagical annotations
anymore, so they're much smaller (244K → 52K, 4.7x smaller).

This fixes #79