### PR TITLE
(fix) Fixes hasInstance for Maybe/Result

### DIFF
--- a/src/data/maybe/index.js
+++ b/src/data/maybe/index.js
@@ -9,6 +9,8 @@
 
 
 const Maybe = require('./maybe');
+const { typeSymbol } = require('folktale/core/adt/data');
+
 
 /*~
  * stability: unstable
@@ -24,6 +26,7 @@ module.exports = {
   hasInstance: Maybe.hasInstance,
   of: Maybe.of,
   fromJSON: Maybe.fromJSON,
+  [typeSymbol]: Maybe[typeSymbol],
   ['fantasy-land/of']: Maybe['fantasy-land/of'],
 
   /*~

--- a/src/data/result/index.js
+++ b/src/data/result/index.js
@@ -8,6 +8,7 @@
 //----------------------------------------------------------------------
 
 const Result = require('./result');
+const { typeSymbol } = require('folktale/core/adt/data');
 
 
 /*~
@@ -20,6 +21,7 @@ module.exports = {
   hasInstance: Result.hasInstance,
   of: Result.of,
   fromJSON: Result.fromJSON,
+  [typeSymbol]: Result[typeSymbol],
   try: require('./try'),
 
   /*~


### PR DESCRIPTION
.hasInstance uses the type in the context object to determine if the value is an instance or not. This was broken when the Maybe and Result modules stopped exporting that (among other) properties.