### PR TITLE
(docs) Add tentative type annotations to Task methods

### DIFF
--- a/src/data/task/_task.js
+++ b/src/data/task/_task.js
@@ -18,14 +18,32 @@ const noop = () => {};
 
 /*~ stability: experimental */
 class Task {
-  /*~*/
+  /*~
+   * stability: experimental
+   *
+   * type Resources = Any
+   *
+   * type Computation = ({ resolve: (value is Any) -> X, reject: (reason is Any) -> X , cancel: () -> X }) -> Resources
+   *
+   * type OnCancel = Resources -> Any
+   *
+   * type Cleanup = Resources -> Any
+   *
+   * type: |
+   *     (Computation, OnCancel, Cleanup) -> Task reason value
+   */
   constructor(computation, onCancel, cleanup) {
     this._computation = computation;
     this._onCancel    = onCancel || noop;
     this._cleanup     = cleanup  || noop;
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b, c:
+   *     (Task a b).((b) => Task a c) => Task a c
+   */
   chain(transformation) {
     return new Task(
       resolver => {
@@ -47,7 +65,12 @@ class Task {
     );
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b, c:
+   *     (Task a b).((b) => c) => Task a c
+   */
   map(transformation) {
     return new Task(
       resolver => {
@@ -63,12 +86,21 @@ class Task {
     );
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b, c:
+   *     (Task a ((b) => c)).(Task a b) => Task a c
+   */
   apply(task) {
     return this.chain(f => task.map(f));
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   (Task a b).((a) => c, (b) => d) => Task c d
+   */
   bimap(rejectionTransformation, successTransformation) {
     return new Task(
       resolver => {
@@ -84,7 +116,18 @@ class Task {
     );
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b, c, d:
+   *     type Pattern = { r |
+   *       Cancelled: ()  => Task c d,
+   *       Resolved:  (b) => Task c d,
+   *       Rejected:  (a) => Task c d
+   *     }
+   *
+   *     (Task a b).(Pattern) => Task c d
+   */
   willMatchWith(pattern) {
     return new Task(
       resolver => {
@@ -105,7 +148,11 @@ class Task {
     );
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b: (Task a b).() => Task b a
+   */
   swap() {
     return new Task(
       resolver => {
@@ -121,7 +168,12 @@ class Task {
     );
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b, c, d:
+   *     (Task a b).(Task c d) => (Task a b) or (Task c d)
+   */
   or(that) {
     return new Task(
       resolver => {
@@ -158,7 +210,11 @@ class Task {
     );
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b, c: (Task a b).(Task a c) => Task a (b, c)
+   */
   and(that) {
     return new Task(
       resolver => {   // eslint-disable-line max-statements
@@ -214,7 +270,11 @@ class Task {
     );
   }
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b: (Task a b).() => TaskExecution a b
+   */
   run() {
     let deferred = new Deferred();    // eslint-disable-line prefer-const
     deferred.listen({
@@ -250,12 +310,20 @@ class Task {
 
 
 Object.assign(Task, {
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b: (b) => Task a b
+   */
   of(value) {
     return new Task(resolver => resolver.resolve(value));
   },
 
-  /*~*/
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall a, b: (a) => Task a b
+   */
   rejected(reason) {
     return new Task(resolver => resolver.reject(reason));
   }

--- a/src/data/task/_task.js
+++ b/src/data/task/_task.js
@@ -36,8 +36,8 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v1, v2, e, r:
-   *     (Task v1 e r).((v1) => Task v2 e r) => Task v2 e r
+   *   forall e, v1, v2, r:
+   *     (Task e v1 r).((v1) => Task e v2 r) => Task e v2 r
    */
   chain(transformation) {
     return new Task(
@@ -63,8 +63,8 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v1, v2, e, r:
-   *     (Task v1 e r).((v1) => v2) => Task v2 e r
+   *   forall e, v1, v2, r:
+   *     (Task e v1 r).((v1) => v2) => Task e v2 r
    */
   map(transformation) {
     return new Task(
@@ -84,8 +84,8 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v1, v2, e, r:
-   *     (Task ((v1) => v2) e r).(Task v1 e r) => Task v2 e r
+   *   forall e, v1, v2, r:
+   *     (Task e ((v1) => v2) r).(Task e v1 r) => Task e v2 r
    */
   apply(task) {
     return this.chain(f => task.map(f));
@@ -94,8 +94,8 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v1, v2, e1, e2, r:
-   *     (Task v1 e1 r).((e1) => e2, (v1) => v2) => Task v2 e2 r
+   *   forall e1, e2, v1, v2, r:
+   *     (Task e1 v1 r).((e1) => e2, (v1) => v2) => Task e2 v2 r
    */
   bimap(rejectionTransformation, successTransformation) {
     return new Task(
@@ -115,14 +115,14 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v1, v2, e1, e2, r:
+   *   forall e1, e2, v1, v2, r:
    *     type Pattern = { row |
-   *       Cancelled: ()  => Task v2 e2 r,
-   *       Resolved:  (b) => Task v2 e2 r,
-   *       Rejected:  (a) => Task v2 e2 r
+   *       Cancelled: ()  => Task e2 v2 r,
+   *       Resolved:  (b) => Task e2 v2 r,
+   *       Rejected:  (a) => Task e2 v2 r
    *     }
    *
-   *     (Task v1 e1 r).(Pattern) => Task v2 e2 r
+   *     (Task e1 v1 r).(Pattern) => Task e2 v2 r
    */
   willMatchWith(pattern) {
     return new Task(
@@ -147,7 +147,7 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v, e, r: (Task v e r).() => Task e v r
+   *   forall e, v, r: (Task e v r).() => Task v e r
    */
   swap() {
     return new Task(
@@ -167,8 +167,8 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v, e, r1, r2:
-   *     (Task v e r1).(Task v e r2) => Task v e (r1 and r2)
+   *   forall e, v, r1, r2:
+   *     (Task e v r1).(Task e v r2) => Task e v (r1 and r2)
    */
   or(that) {
     return new Task(
@@ -209,8 +209,8 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v1, v2, e, r1, r2:
-   *     (Task v1, e, r1).(Task v2, e, r2) => Task (v1, v2) e (r1 and r2)
+   *   forall e, v1, v2, r1, r2:
+   *     (Task e v1 r1).(Task e v2 r2) => Task e (v1 v2) (r1 and r2)
    */
   and(that) {
     return new Task(
@@ -270,7 +270,7 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall v, e, r: (Task v e r).() => TaskExecution v e r
+   *   forall e, v, r: (Task e v r).() => TaskExecution e v r
    */
   run() {
     let deferred = new Deferred();    // eslint-disable-line prefer-const
@@ -310,7 +310,7 @@ Object.assign(Task, {
   /*~
    * stability: experimental
    * type: |
-   *   forall v, e, r: (v) => Task v e r
+   *   forall e, v, r: (v) => Task e v r
    */
   of(value) {
     return new Task(resolver => resolver.resolve(value));
@@ -319,7 +319,7 @@ Object.assign(Task, {
   /*~
    * stability: experimental
    * type: |
-   *   forall v, e, r: (e) => Task v e r
+   *   forall e, v, r: (e) => Task e v r
    */
   rejected(reason) {
     return new Task(resolver => resolver.reject(reason));

--- a/src/data/task/task.js
+++ b/src/data/task/task.js
@@ -11,7 +11,10 @@ const Task = require('./_task');
 
 const noop = () => {};
 
-/*~ stability: experimental */
+/*~
+ * stability: experimental
+ * name: module folktale/data/task
+ */
 const task = (computation, handlers = { onCancelled: noop, cleanup: noop }) =>
   new Task(computation, handlers.onCancelled, handlers.cleanup);
 


### PR DESCRIPTION
1. The `constructor` type annotations are in need of guidance.
2. Special attention needs to be given to `and` and `or` type annotations.
   - `and`, got from [here](https://github.com/origamitower/folktale/pull/50#issuecomment-254876308). Was going to go with: `(Task a b).(Task c d) => (Task a _) or (Task c _) or (Task _ (b, d))`) - why is the rejected part of both Tasks the same type `a`?