### PR TITLE
Makes race conditions harder with the Task API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Folktale can be installed through [npm][]:
 
 
 **Browsers**:
-  - Chrome 23+
+  - Chrome 36+
   - Firefox 21+
   - Safari 6+
   - Internet Explorer 9+
@@ -45,7 +45,7 @@ Folktale can be installed through [npm][]:
 
 **Mobile browsers**:
   - Android 4.4+
-  - iOS 7+
+  - iOS 8.3+
 
 
 The following table summarises tests executed on each supported Browser platform for the current version:

--- a/docs/source/en/data/task/task-execution/cancel.md
+++ b/docs/source/en/data/task/task-execution/cancel.md
@@ -11,12 +11,12 @@ Cancels a task execution. Does nothing if the task has already been resolved.
     
     let message = 'world';
     const helloIn50 = task(
-      resolver => setTimeout(() => {
-        message = 'hello';
-        resolver.resolve();
-      }, 50),
-      {
-        cleanup: (timer) => clearTimeout(timer)
+      resolver => {
+        const timerId = setTimeout(() => {
+          message = 'hello';
+          resolver.resolve();
+        }, 50);
+        resolver.cleanup(() => clearTimeout(timerId));
       }
     );
     

--- a/docs/source/en/data/task/task/and.md
+++ b/docs/source/en/data/task/task/and.md
@@ -16,9 +16,11 @@ If you need to combine more than two tasks concurrently, take a look at the `wai
     const { task } = require('folktale/data/task');
     
     const delay = (ms) => task(
-      resolver => setTimeout(() => resolver.resolve(ms), ms),
-      {
-        cleanup: (timer) => clearTimeout(timer)
+      resolver => {
+        const timerId = setTimeout(() => resolver.resolve(ms), ms);
+        resolver.cleanup(() => {
+          clearTimeout(timerId);
+        });
       }
     );
     

--- a/docs/source/en/data/task/task/or.md
+++ b/docs/source/en/data/task/task/or.md
@@ -18,16 +18,20 @@ As a convenience for combining a large or unknown amount of tasks, the
     const { task } = require('folktale/data/task');
 
     const delay = (ms) => task(
-      resolver => setTimeout(() => resolver.resolve(ms), ms),
-      {
-        cleanup: (timer) => clearTimeout(timer)
+      resolver => {
+        const timerId = setTimeout(() => resolver.resolve(ms), ms);
+        resolver.cleanup(() => {
+          clearTimeout(timerId);
+        });
       }
     );
 
     const timeout = (ms) => task(
-      resolver => setTimeout(() => resolver.reject(ms), ms),
-      {
-        cleanup: (timer) => clearTimeout(timer)
+      resolver => {
+        const timerId = setTimeout(() => resolver.reject(ms), ms);
+        resolver.cleanup(() => {
+          clearTimeout(timerId);
+        });
       }
     );
 

--- a/docs/source/en/data/task/wait-any.md
+++ b/docs/source/en/data/task/wait-any.md
@@ -19,9 +19,11 @@ any of the input tasks resolving will also cancel all of the other input tasks.
     const { task, waitAny } = require('folktale/data/task');
     
     const delay = (ms) => task(
-      resolver => setTimeout(() => resolver.resolve(ms), ms),
-      {
-        cleanup: (timer) => clearTimeout(timer)
+      resolver => {
+        const timerId = setTimeout(() => resolver.resolve(ms), ms);
+        resolver.cleanup(() => {
+          clearTimeout(timerId);
+        })
       }
     );
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "folktale",
-  "version": "2.0.0-beta1",
+  "version": "2.0.0-beta2",
   "description": "A suite of libraries for generic functional programming in JavaScript that allows you to write elegant modular applications with fewer bugs and more reuse.",
   "main": "./index.js",
   "scripts": {

--- a/src/data/task/_task.js
+++ b/src/data/task/_task.js
@@ -21,93 +21,90 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall value, reason, resources:
+   *   forall value, reason:
    *     new (
-   *       ({ resolve: (value) => Void, reject: (reason) => Void, cancel: () => Void }) => resources,
-   *       (resources) => Void,
-   *       (resources) => Void
-   *     ) => Task value reason resources
+   *       ({
+   *          resolve: (value) => Void,
+   *          reject: (reason) => Void,
+   *          cancel: () => Void,
+   *          cleanup: (() => Void) => Void,
+   *          onCancelled: (() => Void) => Void,
+   *          get isCancelled: Boolean
+   *        }) => Void
+   *     ) => Task value reason
    */
-  constructor(computation, onCancel, cleanup) {
+  constructor(computation) {
     this._computation = computation;
-    this._onCancel    = onCancel || noop;
-    this._cleanup     = cleanup  || noop;
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v1, v2, r:
-   *     (Task e v1 r).((v1) => Task e v2 r) => Task e v2 r
+   *   forall e, v1, v2:
+   *     (Task e v1).((v1) => Task e v2) => Task e v2
    */
   chain(transformation) {
-    return new Task(
-      resolver => {
-        const execution = this.run();
-        execution.listen({
-          onCancelled: resolver.cancel,
-          onRejected:  resolver.reject,
-          onResolved:  value => {
-            transformation(value).run().listen({
-              onCancelled: resolver.cancel,
-              onRejected:  resolver.reject,
-              onResolved:  resolver.resolve
-            });
-          }
-        });
-        return execution;
-      },
-      execution => execution.cancel()
-    );
+    return new Task(resolver => {
+      const execution = this.run();
+      resolver.onCancelled(() => execution.cancel());
+
+      execution.listen({
+        onCancelled: resolver.cancel,
+        onRejected:  resolver.reject,
+        onResolved:  value => {
+          transformation(value).run().listen({
+            onCancelled: resolver.cancel,
+            onRejected:  resolver.reject,
+            onResolved:  resolver.resolve
+          });
+        }
+      });
+    });
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v1, v2, r:
-   *     (Task e v1 r).((v1) => v2) => Task e v2 r
+   *   forall e, v1, v2:
+   *     (Task e v1).((v1) => v2) => Task e v2
    */
   map(transformation) {
-    return new Task(
-      resolver => {
-        const execution = this.run();
-        execution.listen({
-          onCancelled: resolver.cancel,
-          onRejected:  resolver.reject,
-          onResolved:  value => resolver.resolve(transformation(value))
-        });
-        return execution;
-      },
-      execution => execution.cancel()
-    );
+    return new Task(resolver => {
+      const execution = this.run();
+      resolver.onCancelled(() => execution.cancel());
+
+      execution.listen({
+        onCancelled: resolver.cancel,
+        onRejected:  resolver.reject,
+        onResolved:  value => resolver.resolve(transformation(value))
+      });
+    });
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e1, e2, v, r:
-   *     (Task e1 v r).((e1) => e2) => Task e2 v r
+   *   forall e1, e2, v:
+   *     (Task e1 v).((e1) => e2) => Task e2 v
    */
   mapRejected(transformation) {
-    return new Task(
-      resolver => {
-        const execution = this.run();
-        execution.listen({
-          onCancelled: resolver.cancel,
-          onRejected:  reason => resolver.reject(transformation(reason)),
-          onResolved:  resolver.resolve
-        });
-        return execution;
-      },
-      execution => execution.cancel()
-    );
+    return new Task(resolver => {
+      const execution = this.run();
+      resolver.onCancelled(() => execution.cancel());
+
+      execution.listen({
+        onCancelled: resolver.cancel,
+        onRejected:  reason => resolver.reject(transformation(reason)),
+        onResolved:  resolver.resolve
+      });
+    });
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v1, v2, r:
-   *     (Task e ((v1) => v2) r).(Task e v1 r) => Task e v2 r
+   *   forall e, v1, v2:
+   *     (Task e ((v1) => v2)).(Task e v1) => Task e v2
    */
   apply(task) {
     return this.chain(f => task.map(f));
@@ -116,239 +113,248 @@ class Task {
   /*~
    * stability: experimental
    * type: |
-   *   forall e1, e2, v1, v2, r:
-   *     (Task e1 v1 r).((e1) => e2, (v1) => v2) => Task e2 v2 r
+   *   forall e1, e2, v1, v2:
+   *     (Task e1 v1).((e1) => e2, (v1) => v2) => Task e2 v2
    */
   bimap(rejectionTransformation, successTransformation) {
-    return new Task(
-      resolver => {
-        const execution = this.run();
-        execution.listen({
-          onCancelled: resolver.cancel,
-          onRejected:  reason => resolver.reject(rejectionTransformation(reason)),
-          onResolved:  value => resolver.resolve(successTransformation(value))
-        });
-        return execution;
-      },
-      execution => execution.cancel()
-    );
+    return new Task(resolver => {
+      const execution = this.run();
+      resolver.onCancelled(() => execution.cancel());
+
+      execution.listen({
+        onCancelled: resolver.cancel,
+        onRejected:  reason => resolver.reject(rejectionTransformation(reason)),
+        onResolved:  value => resolver.resolve(successTransformation(value))
+      });
+    });
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e1, e2, v1, v2, r:
+   *   forall e1, e2, v1, v2:
    *     type Pattern = { row |
-   *       Cancelled: ()  => Task e2 v2 r,
-   *       Resolved:  (b) => Task e2 v2 r,
-   *       Rejected:  (a) => Task e2 v2 r
+   *       Cancelled: ()  => Task e2 v2,
+   *       Resolved:  (b) => Task e2 v2,
+   *       Rejected:  (a) => Task e2 v2
    *     }
    *
-   *     (Task e1 v1 r).(Pattern) => Task e2 v2 r
+   *     (Task e1 v1).(Pattern) => Task e2 v2
    */
   willMatchWith(pattern) {
-    return new Task(
-      resolver => {
-        const execution = this.run();
-        const resolve = (handler) => (value) => handler(value).run().listen({
-          onCancelled: resolver.cancel,
-          onRejected:  resolver.reject,
-          onResolved:  resolver.resolve
-        });
-        execution.listen({
-          onCancelled: resolve(_ => pattern.Cancelled()),
-          onRejected:  resolve(pattern.Rejected),
-          onResolved:  resolve(pattern.Resolved)
-        });
-        return execution;
-      },
-      execution => execution.cancel()
-    );
+    return new Task(resolver => {
+      const execution = this.run();
+      resolver.onCancelled(() => execution.cancel());
+      
+      const resolve = (handler) => (value) => handler(value).run().listen({
+        onCancelled: resolver.cancel,
+        onRejected:  resolver.reject,
+        onResolved:  resolver.resolve
+      });
+      execution.listen({
+        onCancelled: resolve(_ => pattern.Cancelled()),
+        onRejected:  resolve(pattern.Rejected),
+        onResolved:  resolve(pattern.Resolved)
+      });
+    });
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v, r: (Task e v r).() => Task v e r
+   *   forall e, v: (Task e v).() => Task v e
    */
   swap() {
-    return new Task(
-      resolver => {
-        let execution = this.run();   // eslint-disable-line prefer-const
-        execution.listen({
-          onCancelled: resolver.cancel,
-          onRejected:  resolver.resolve,
-          onResolved:  resolver.reject
-        });
-        return execution;
-      },
-      execution => execution.cancel()
-    );
+    return new Task(resolver => {
+      let execution = this.run();   // eslint-disable-line prefer-const
+      resolver.onCancelled(() => execution.cancel());
+
+      execution.listen({
+        onCancelled: resolver.cancel,
+        onRejected:  resolver.resolve,
+        onResolved:  resolver.reject
+      });
+    });
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e, e2, v, r1, r2:
-   *     (Task e v r1).((e) => Task e2 v r2) => Task e2 v r2
+   *   forall e, e2, v:
+   *     (Task e v).((e) => Task e2 v) => Task e2 v
    */
   orElse(handler) {
-    return new Task(
-      resolver => {
-        const execution = this.run();
-        execution.listen({
-          onCancelled: resolver.cancel,
-          onResolved:  resolver.resolve,
-          onRejected:  reason => {
-            handler(reason).run().listen({
-              onCancelled: resolver.cancel,
-              onRejected:  resolver.reject,
-              onResolved:  resolver.resolve
-            });
-          }
-        });
-        return execution;
-      },
-      execution => execution.cancel()
-    );
+    return new Task(resolver => {
+      const execution = this.run();
+      resolver.onCancelled(() => execution.cancel());
+
+      execution.listen({
+        onCancelled: resolver.cancel,
+        onResolved:  resolver.resolve,
+        onRejected:  reason => {
+          handler(reason).run().listen({
+            onCancelled: resolver.cancel,
+            onRejected:  resolver.reject,
+            onResolved:  resolver.resolve
+          });
+        }
+      });
+    });
   }
 
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v, r1, r2:
-   *     (Task e v r1).(Task e v r2) => Task e v (r1 and r2)
+   *   forall e, v:
+   *     (Task e v).(Task e v) => Task e v
    */
   or(that) {
-    return new Task(
-      resolver => {
-        let thisExecution = this.run();   // eslint-disable-line prefer-const
-        let thatExecution = that.run();   // eslint-disable-line prefer-const
-        let done = false;
+    return new Task(resolver => {
+      let thisExecution = this.run();   // eslint-disable-line prefer-const
+      let thatExecution = that.run();   // eslint-disable-line prefer-const
+      let done = false;
 
-        const guard = (fn, execution) => (value) => {
-          if (!done) {
-            done = true;
-            execution.cancel();
-            fn(value);
-          }
-        };
-
-        thisExecution.listen({
-          onRejected:  guard(resolver.reject, thatExecution),
-          onCancelled: guard(resolver.cancel, thatExecution),
-          onResolved:  guard(resolver.resolve, thatExecution)
-        });
-
-        thatExecution.listen({
-          onRejected:  guard(resolver.reject, thisExecution),
-          onCancelled: guard(resolver.cancel, thisExecution),
-          onResolved:  guard(resolver.resolve, thisExecution)
-        });
-
-        return [thisExecution, thatExecution];
-      },
-      ([thisExecution, thatExecution]) => {
+      resolver.onCancelled(() => {
         thisExecution.cancel();
         thatExecution.cancel();
-      }
-    );
-  }
+      });
 
-  /*~
-   * stability: experimental
-   * type: |
-   *   forall e, v1, v2, r1, r2:
-   *     (Task e v1 r1).(Task e v2 r2) => Task e (v1, v2) (r1 and r2)
-   */
-  and(that) {
-    return new Task(
-      resolver => {   // eslint-disable-line max-statements
-        let thisExecution = this.run();   // eslint-disable-line prefer-const
-        let thatExecution = that.run();   // eslint-disable-line prefer-const
-        let valueLeft = null;
-        let valueRight = null;
-        let doneLeft = false;
-        let doneRight = false;
-        let cancelled = false;
-
-        const guardResolve = (setter) => (value) => {
-          if (cancelled)  return;
-
-          setter(value);
-          if (doneLeft && doneRight) {
-            resolver.resolve([valueLeft, valueRight]);
-          }
-        };
-
-        const guardRejection = (fn, execution) => (value) => {
-          if (cancelled)  return;
-
-          cancelled = true;
+      const guard = (fn, execution) => (value) => {
+        if (!done) {
+          done = true;
           execution.cancel();
           fn(value);
-        };
+        }
+      };
 
-        thisExecution.listen({
-          onRejected:  guardRejection(resolver.reject, thatExecution),
-          onCancelled: guardRejection(resolver.cancel, thatExecution),
-          onResolved:  guardResolve(x => {
-            valueLeft = x;
-            doneLeft = true;
-          })
-        });
+      thisExecution.listen({
+        onRejected:  guard(resolver.reject, thatExecution),
+        onCancelled: guard(resolver.cancel, thatExecution),
+        onResolved:  guard(resolver.resolve, thatExecution)
+      });
 
-        thatExecution.listen({
-          onRejected:  guardRejection(resolver.reject, thisExecution),
-          onCancelled: guardRejection(resolver.cancel, thisExecution),
-          onResolved:  guardResolve(x => {
-            valueRight = x;
-            doneRight = true;
-          })
-        });
-
-        return [thisExecution, thatExecution];
-      },
-      ([thisExecution, thatExecution]) => {
-        thisExecution.cancel();
-        thatExecution.cancel();
-      }
-    );
+      thatExecution.listen({
+        onRejected:  guard(resolver.reject, thisExecution),
+        onCancelled: guard(resolver.cancel, thisExecution),
+        onResolved:  guard(resolver.resolve, thisExecution)
+      });
+    });
   }
 
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v, r: (Task e v r).() => TaskExecution e v r
+   *   forall e, v1, v2:
+   *     (Task e v1).(Task e v2) => Task e (v1, v2)
+   */
+  and(that) {
+    return new Task(resolver => {   // eslint-disable-line max-statements
+      let thisExecution = this.run();   // eslint-disable-line prefer-const
+      let thatExecution = that.run();   // eslint-disable-line prefer-const
+      let valueLeft = null;
+      let valueRight = null;
+      let doneLeft = false;
+      let doneRight = false;
+      let cancelled = false;
+
+      resolver.onCancelled(() => {
+        thisExecution.cancel();
+        thatExecution.cancel();
+      });
+
+      const guardResolve = (setter) => (value) => {
+        if (cancelled)  return;
+
+        setter(value);
+        if (doneLeft && doneRight) {
+          resolver.resolve([valueLeft, valueRight]);
+        }
+      };
+
+      const guardRejection = (fn, execution) => (value) => {
+        if (cancelled)  return;
+
+        cancelled = true;
+        execution.cancel();
+        fn(value);
+      };
+
+      thisExecution.listen({
+        onRejected:  guardRejection(resolver.reject, thatExecution),
+        onCancelled: guardRejection(resolver.cancel, thatExecution),
+        onResolved:  guardResolve(x => {
+          valueLeft = x;
+          doneLeft = true;
+        })
+      });
+
+      thatExecution.listen({
+        onRejected:  guardRejection(resolver.reject, thisExecution),
+        onCancelled: guardRejection(resolver.cancel, thisExecution),
+        onResolved:  guardResolve(x => {
+          valueRight = x;
+          doneRight = true;
+        })
+      });
+    });
+  }
+
+  /*~
+   * stability: experimental
+   * type: |
+   *   forall e, v: (Task e v).() => TaskExecution e v
    */
   run() {
     let deferred = new Deferred();    // eslint-disable-line prefer-const
+    let cleanups      = [];
+    let cancellations = [];
+    let isCancelled   = false;
+    let done          = false;
+
     deferred.listen({
       onCancelled: _ => {
-        defer(_ => {
-          this._onCancel(resources);
-          this._cleanup(resources);
-        });
+        done = true;
+        isCancelled = true;
+        cancellations.forEach(f => f());
+        cleanups.forEach(f => f());
+        cancellations = [];
+        cleanups = [];
       },
 
       onResolved: _value => {
-        defer(_ => {
-          this._cleanup(resources);
-        });
+        done = true;
+        cleanups.forEach(f => f());
+        cleanups = [];
+        cancellations = [];
       },
 
       onRejected: _reason => {
-        defer(_ => {
-          this._cleanup(resources);
-        });
+        done = true;
+        cleanups.forEach(f => f());
+        cleanups = [];
+        cancellations = [];
       }
     });
 
     const resources = this._computation({
       reject:  error => { deferred.reject(error) },
       resolve: value => { deferred.resolve(value) },
-      cancel:  _     => { deferred.maybeCancel() }
+      cancel:  _     => { deferred.maybeCancel() },
+
+      get isCancelled() { return isCancelled },
+      cleanup(f) {
+        if (done) {
+          throw new Error('Can\'t attach a cleanup handler after the task is settled.');
+        }
+        cleanups.push(f);
+      },
+      onCancelled(f) {
+        if (done) {
+          throw new Error('Can\'t attach a cancellation handler after the task is settled.');
+        }
+        cancellations.push(f);
+      }
     });
 
     return new TaskExecution(this, deferred);
@@ -360,7 +366,7 @@ Object.assign(Task, {
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v, r: (v) => Task e v r
+   *   forall e, v: (v) => Task e v
    */
   of(value) {
     return new Task(resolver => resolver.resolve(value));
@@ -369,7 +375,7 @@ Object.assign(Task, {
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v, r: (e) => Task e v r
+   *   forall e, v: (e) => Task e v
    */
   rejected(reason) {
     return new Task(resolver => resolver.reject(reason));

--- a/src/data/task/index.js
+++ b/src/data/task/index.js
@@ -25,10 +25,10 @@ module.exports = {
   /*~
    * stability: experimental
    * type: |
-   *    forall s, e, r:
+   *    forall s, e:
    *      ((Any..., (e, s) => Void) => Void)
    *      => (Any...)
-   *      => Task e s r
+   *      => Task e s
    */
   fromNodeback(aNodeback) {
     return require('folktale/data/conversions/nodeback-to-task')(aNodeback);
@@ -37,8 +37,8 @@ module.exports = {
   /*~
    * stability: experimental
    * type: |
-   *   forall e, v, r:
-   *     ((Any...) => Promise v e) => (Any...) => Task e v r
+   *   forall e, v:
+   *     ((Any...) => Promise v e) => (Any...) => Task e v
    */
   fromPromised(aPromiseFn) {
     return require('folktale/data/conversions/promised-to-task')(aPromiseFn);

--- a/src/data/task/index.js
+++ b/src/data/task/index.js
@@ -9,6 +9,7 @@
 
 const Task = require('./_task');
 
+
 /*~ 
  * stability: experimental 
  * name: module folktale/data/task

--- a/src/data/task/task.js
+++ b/src/data/task/task.js
@@ -14,17 +14,20 @@ const noop = () => {};
 /*~
  * stability: experimental
  * type: |
- *   forall value, reason, resources:
+ *   forall value, reason:
  *     (
- *       ({ resolve: (value) => Void, reject: (reason) => Void, cancel: () => Void }) => resources,
- *       {
- *         onCancelled: (resources) => Void,
- *         cleanup: (resources) => Void
- *       }
- *     ) => Task reason value resources
+ *       ({
+ *          resolve: (value) => Void,
+ *          reject: (reason) => Void,
+ *          cancel: () => Void,
+ *          cleanup: (() => Void) => Void,
+ *          onCancelled: (() => Void) => Void,
+ *          get isCancelled: Boolean
+ *        }) => Void
+ *     ) => Task reason value
  */
-const task = (computation, handlers = { onCancelled: noop, cleanup: noop }) =>
-  new Task(computation, handlers.onCancelled, handlers.cleanup);
+const task = (computation) =>
+  new Task(computation);
 
 
 module.exports = task;

--- a/test/karma-sauce.js
+++ b/test/karma-sauce.js
@@ -32,8 +32,8 @@ module.exports = function(config) {
 
   const customLaunchers = merge(
     // Desktop browsers
-    browser('Linux', 'chrome', ['36', 'latest-2', 'latest']),
-    browser('Linux', 'firefox', ['21', 'latest-2', 'latest']),
+    browser('Linux', 'chrome', ['36', 'latest']),
+    browser('Linux', 'firefox', ['21', 'latest']),
     browser('OS X 10.8', 'safari', ['6']),
     browser('OS X 10.9', 'safari', ['7']),
     browser('OS X 10.10', 'safari', ['8']),
@@ -43,14 +43,14 @@ module.exports = function(config) {
     browser('Windows 10', 'MicrosoftEdge', ['13']),
 
     // Mobile browsers
-    mobile('Android', 'Browser', ['4.4', '5', '5.1'], {
+    mobile('Android', 'Browser', ['4.4', '5'], {
       deviceName: 'Android Emulator',
       deviceType: 'phone',
       deviceOrientation: 'portrait',
       appiumVersion: '1.5.3'
     }),
 
-    mobile('iOS', 'Safari', ['8.4', '9.3', '10.2'], {
+    mobile('iOS', 'Safari', ['8.4', '9.3'], {
       deviceOrientation: 'portrait',
       deviceName: 'iPhone Simulator',
       appiumVersion: '1.6.3'
@@ -108,9 +108,10 @@ module.exports = function(config) {
 
     // Concurrency level
     // how many browser should be started simultaneous
-    concurrency: 3,
+    concurrency: 1,
 
-    browserDiconnectTimeout: 60000,
-    browserNoActivityTimeout: 180000
+    captureTimeout: 180 * 1000,
+    browserDiconnectTimeout: 180 * 1000,
+    browserNoActivityTimeout: 180 * 1000
   });
 }

--- a/test/specs-src/data.task.js
+++ b/test/specs-src/data.task.js
@@ -314,8 +314,9 @@ describe('Data.Task', () => {
   });
 
   it('waitAny()', async () => {
-    const delay = (ms) => Task.task((r) => setTimeout(() => r.resolve(ms), ms), {
-      cleanup: (a) => clearTimeout(a)
+    const delay = (ms) => Task.task((r) => {
+      const timer = setTimeout(() => r.resolve(ms), ms);
+      r.cleanup(() => clearTimeout(timer));
     });
 
     const result = await Task.waitAny([delay(100), delay(30), delay(200)]).run().promise();


### PR DESCRIPTION
Previously the Task API had separate functions for cleanup and for handling cancellation. These functions were defined outside of the Task computation, which means Task had to return references to the allocated resources so those functions could do their jobs.

This obviously didn't work for places where resolution happened synchronously, as they'd have to be called before those references were returned. Calling them asynchronously meant that race conditions on when exactly "cancellation/cleanup" and pending resolutions happen were possible. Which is not a good thing.

Merely making all resolutions asynchronous wouldn't really fix the issue, although it would have made it less likely to happen.

Anyway, I decided to have the computation itself add handlers for cancellation and cleanup events, and those can be just called synchronously, as they'd have access to the resources in the task's scope — testing for the existence of a resource is still required, as cancellation may happen before a particular resource is properly initialised.

What this means is basically:

```js
    // BEFORE
    task(
      resolver => {
        const res = doThings(() => {
          resolver.resolve(value);
        });
        return res;
      },
      res => { cleanup... },
      res => { cancellation... }
    );

    // AFTER
    task(
      resolver => {
        const res = doThings(() => {
          resolver.resolve(value);
        });
        return res;
      }
    );
```

Cancellation and cleanup handlers must be attached *before* a task resolves. It's an error to try attaching them after a task is resolved.

This should fix #83… hopefully…