### PR TITLE
Adds Task.do

### DIFF
--- a/packages/base/source/concurrency/task/do.js
+++ b/packages/base/source/concurrency/task/do.js
@@ -1,0 +1,35 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// Licensed under MIT. See LICENCE for full licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const Task = require('./_task');
+
+/*~
+ * stability: experimental
+ * type: |
+ *   forall v, e: (GeneratorInstance [Task e v Any]) => Any => Task e [v] Any
+ */
+const runGenerator = (generator, value) => (resolver) => {
+  const { value: task, done } = generator.next(value);
+  task.run().listen({
+    onCancelled: resolver.cancel,
+    onResolved: (result) => 
+      !done ? runGenerator(generator, result)(resolver)
+      :       resolver.resolve(result),
+    onRejected: resolver.reject
+  });
+};
+
+/*~
+ * stability: experimental
+ * type: |
+ *   forall v, e: (Generator [Task e v Any]) => Task e [v] Any
+ */
+const taskDo = generator => new Task(runGenerator(generator()));
+
+module.exports = taskDo;

--- a/packages/base/source/concurrency/task/do.js
+++ b/packages/base/source/concurrency/task/do.js
@@ -30,6 +30,8 @@ const runGenerator = (generator, value) => (resolver) => {
  * type: |
  *   forall v, e: (Generator [Task e v Any]) => Task e [v] Any
  */
-const taskDo = generator => new Task(runGenerator(generator()));
+const taskDo = generator => 
+  new Task((resolver) => 
+    runGenerator(generator())(resolver));
 
 module.exports = taskDo;

--- a/packages/base/source/concurrency/task/index.js
+++ b/packages/base/source/concurrency/task/index.js
@@ -20,6 +20,7 @@ module.exports = {
   task: require('./task'),
   waitAny: require('./wait-any'),
   waitAll: require('./wait-all'),
+  do: require('./do'),
   _Task: Task,
   _TaskExecution: require('./_task-execution'),
 

--- a/test/source/specs/base/concurrency/task.js
+++ b/test/source/specs/base/concurrency/task.js
@@ -357,6 +357,17 @@ describe('Data.Task', () => {
       exceptionThrown[1] = true;
     });
     $ASSERT(exceptionThrown[1] == true);
+
+    const multipleCallsResults = [];
+    const multipleCallsTask = await Task.do(function *() {
+      const a = yield delay(10); 
+      return Task.of(a);
+    });
+    multipleCallsResults[0] = await multipleCallsTask.run().promise();
+    multipleCallsResults[1] = await multipleCallsTask.run().promise();
+
+    $ASSERT(multipleCallsResults[0] == 10);
+    $ASSERT(multipleCallsResults[1] == 10);
   });
 
 


### PR DESCRIPTION
As per issue #111.
I've seen it's scheduled for `post-2.0` but I had the code lying around and I love my (syntactic) sugar.

It can be used like this:
```
Task.do(function *() {
  const a = yield delay(10); 
  const b = yield delay(11); 
  const c = yield Task.of(5);
  return Task.of(a + b + c + 4);
})
```

Right now all the yielded / returned values need to be an instance of Task and behave like Haskell's bind, while in JavaScript (async/await, coroutines) values get promisified if they're not Promises.

I personally think it's confusing to promisify things implicitly and caused a few misunderstanding while teaching newcomers.
What do you think about it?

EDIT: I forgot to say, I'm not sure I followed the right convention for the type annotation, so that may need some fixing

Thanks