### PR TITLE
Allow Task.waitAll to take an empty list of tasks

### DIFF
--- a/packages/base/CONTRIBUTORS
+++ b/packages/base/CONTRIBUTORS
@@ -13,3 +13,4 @@
 - Kris Reeves (https://github.com/myndzi)
 - Tenor Biel (https://github.com/L8D)
 - Juan Soto (https://github.com/sotojuan)
+- Jordan Ryan Reuter <oss@jreut.com> (https://www.jreut.com)

--- a/packages/base/source/concurrency/task/wait-all.js
+++ b/packages/base/source/concurrency/task/wait-all.js
@@ -15,10 +15,6 @@ const { of } = require('./_task');
  *   forall v, e: ([Task e v Any]) => Task e [v] Any
  */
 const waitAll = (tasks) => {
-  if (tasks.length === 0) {
-    throw new Error('Task.waitAll() requires a non-empty array of tasks.');
-  }
-
   return tasks.reduce(
     (a, b) => a.and(b).map(([xs, x]) => [...xs, x]),
     of([])

--- a/test/source/specs/base/concurrency/task.js
+++ b/test/source/specs/base/concurrency/task.js
@@ -311,6 +311,9 @@ describe('Data.Task', () => {
 
     const result2 = await Task.waitAll([Task.of(1), Task.rejected(2), Task.of(3)]).run().promise().catch(e => e);
     $ASSERT(result2 == 2);
+
+    const result3 = await Task.waitAll([]).run().promise();
+    $ASSERT(result3 == []);
   });
 
   it('waitAny()', async () => {


### PR DESCRIPTION
This change removes a guard on the length of the list passed to `Task.waitAll`.

Let me know if there are any other changes needed to make this pull request acceptable.

Thanks!

Closes #130