### PR TITLE
Fix Success value in `notEmpty` validation example

### DIFF
--- a/annotations/source/en/validation/index.md
+++ b/annotations/source/en/validation/index.md
@@ -153,7 +153,7 @@ Neither of those are very compelling. The Validation structure gives you a tool 
     const { Success, Failure } = Validation;
 
     const notEmpty = (field, value) =>
-      value.trim() ?   Success(field)
+      value.trim() ?   Success(value)
     : /* else */       Failure([`${field} can't be empty`]);
 
     const minLength = (field, min, value) =>


### PR DESCRIPTION
I was reading through the `Validation` documentation and noticed this little typo(?). I'm correct in assuming that the validators should return their `value` property in a `Success`, not the `field`, right?

~~Sorry about the extra `\n` at EOF. I made this patch with the Github editor and it looks like it just tacked that on. I can kill it if y'all prefer.~~ Making the change in the markdown file made this comment moot.