### PR TITLE
Tasks, Concurrency, and Cancellation

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "folktale",
-  "version": "2.1.0-rc1",
+  "version": "2.2.0-alpha1",
   "description": "A suite of libraries for generic functional programming in JavaScript that allows you to write elegant modular applications with fewer bugs and more reuse.",
   "main": "./index.js",
   "repository": {

--- a/packages/base/source/concurrency/task/_task-execution.js
+++ b/packages/base/source/concurrency/task/_task-execution.js
@@ -13,11 +13,13 @@ class TaskExecution {
   constructor(task, deferred) {
     this._task = task;
     this._deferred = deferred;
+    this._links = [];
   }
 
   /*~*/
   cancel() {
     this._deferred.maybeCancel();
+    this._links.forEach(link => link.cancel());
     return this;
   }
 
@@ -35,6 +37,12 @@ class TaskExecution {
   /*~*/
   future() {
     return this._deferred.future();
+  }
+
+  /*~*/
+  link(execution) {
+    this._links.push(execution);
+    return this;
   }
 }
 

--- a/packages/base/source/concurrency/task/_task.js
+++ b/packages/base/source/concurrency/task/_task.js
@@ -342,7 +342,7 @@ class Task {
     const resources = this._computation({
       reject:  error => { deferred.reject(error) },
       resolve: value => { deferred.resolve(value) },
-      cancel:  _     => { deferred.maybeCancel(); },
+      cancel:  _     => { deferred.maybeCancel() },
 
       get isCancelled() { return isCancelled },
       cleanup(f) {

--- a/test/source/browser/browser-tests.js
+++ b/test/source/browser/browser-tests.js
@@ -16,6 +16,7 @@ process.env.FOLKTALE_ASSERTIONS = 'none';
 require('../specs/base/adt/union');
 require('../specs/base/concurrency/future');
 require('../specs/base/concurrency/task');
+require('../specs/base/concurrency/regression/task-cancellation-174');
 require('../specs/base/core/lambda');
 require('../specs/base/core/object');
 require('../specs/base/fantasy-land/fantasy-land');

--- a/test/source/specs/base/concurrency/regression/task-cancellation-174.js
+++ b/test/source/specs/base/concurrency/regression/task-cancellation-174.js
@@ -1,0 +1,59 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// Licensed under MIT. See LICENCE for full licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+// See https://github.com/origamitower/folktale/issues/174 for details
+
+const { task } = require('folktale/concurrency/task');
+
+it('concurrency Regression: chained tasks are not cancelled if partially settled', (done) => {
+  const started = [];
+  const finished = [];
+  let isCancelled = false;
+
+  const delay = (ms, data) => task(resolver => {
+    started.push(data);
+    const timer = setTimeout(() => {
+      finished.push(data);
+      if (isCancelled)  return;
+      resolver.resolve(data)
+    }, ms);
+    resolver.onCancelled(() => clearTimeout(timer));
+  });
+
+  const chain = delay(100, 'a')
+    .chain(x => delay(100, 'b'))
+    .chain(x => delay(100, 'c'));
+
+  const execution = chain.run();
+  setTimeout(() => {
+    isCancelled = true;
+    execution.cancel()
+  }, 150);
+
+  execution.listen({
+    onCancelled: () => {
+      if (started.join(',') === 'a,b' && finished.join(',') === 'a') {
+        done(null);
+      } else {
+        done(new Error(`Task was cancelled, but expected a and b to be started, but only a to be finished. 
+Got ${started.join(', ')} started and ${finished.join(', ')} finished`));
+      }
+    },
+
+    onResolved: () => {
+      done(new Error(`Expected task chain to be cancelled, but they were resolved.`));
+    },
+
+    onRejected: () => {
+      done(new Error(`Expected task chain to be cancelled, but they were rejected.`));
+    }
+  })
+
+
+});


### PR DESCRIPTION
Tasks are still experimental and they're developed in a fairly adhoc manner. This results in a lot of edge cases that are hard to cover under concurrent execution (races are always a pain), and makes it harder for people to reason about their code. #174 and #153 are examples of that.

The current PR includes an initial mitigation  of #174 until Tasks are formalised. The common problems of cancelling tasks are solved by this, but there's no way of knowing if other edge cases exist without formalising.

You can try out these changes by installing version `2.2.0-alpha1`, or just grab the `@next` branch: 

    npm i folktale@next


