### PR TITLE
Feat/typescript abstractions

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@
 - Juan Soto (https://github.com/sotojuan)
 - Florian (https://github.com/floriansimon1)
 - Jordan Ryan Reuter <oss@jreut.com> (https://www.jreut.com)
+- David Li-Bland <david.libland@gmail.com> (https://github.com/davidlibland)

--- a/source/abstract/applicative.ts
+++ b/source/abstract/applicative.ts
@@ -1,0 +1,28 @@
+/*
+----------------------------------------------------------------------
+
+ This source file is part of the Folktale project.
+
+ Licensed under MIT. See LICENCE for full licence information.
+ See CONTRIBUTORS for the list of contributors to the project.
+
+----------------------------------------------------------------------
+*/
+
+import { Functor } from './functor';
+import {Monad} from './monad';
+
+export abstract class Applicative<A> extends Functor<A> {
+    /* This is defined in Functor, but we introduced more stringent typing: */
+    abstract map<B>(fn: (_: A) => B): Applicative<B>;
+    /* This is required to meet the applicative spec: */
+    abstract apply<B, C>(this: Applicative<(_: B) => C>, x: Applicative<B>): Applicative<C>;
+    /* Derived methods: */
+    ap<C>(apfn: Applicative<(_: A) => C>): Applicative<C> {
+        return apfn.apply(this);
+    }
+}
+
+export interface StaticApplicative<A> {
+    of(_: A): Applicative<A>
+}

--- a/source/abstract/functor.ts
+++ b/source/abstract/functor.ts
@@ -1,0 +1,14 @@
+/*
+----------------------------------------------------------------------
+
+ This source file is part of the Folktale project.
+
+ Licensed under MIT. See LICENCE for full licence information.
+ See CONTRIBUTORS for the list of contributors to the project.
+
+----------------------------------------------------------------------
+*/
+
+export abstract class Functor<A> {
+    abstract map<B>(fn: (_: A) => B): Functor<B>;
+}

--- a/source/abstract/monad.ts
+++ b/source/abstract/monad.ts
@@ -1,0 +1,33 @@
+/*
+----------------------------------------------------------------------
+
+ This source file is part of the Folktale project.
+
+ Licensed under MIT. See LICENCE for full licence information.
+ See CONTRIBUTORS for the list of contributors to the project.
+
+----------------------------------------------------------------------
+*/
+
+import {Applicative, StaticApplicative} from './applicative';
+
+export abstract class Monad<A> extends Applicative<A> {
+    /* This is defined in Applicative, but we introduced more stringent typing: */
+    abstract map<B>(fn: (_: A) => B): Monad<B>;
+    /* This is required to meet the monad spec: */
+    abstract chain<B>(_: (_: A) => Monad<B>): Monad<B>;
+    /* Derived methods: */
+    apply<B, C>(this: Monad<(_: B) => C>, x: Monad<B>): Monad<C> {
+        return this.chain((apfn) => x.map(apfn));
+    }
+    bind<B>(fn: (_: A) => Monad<B>): Monad<B> {
+        return this.chain(fn);
+    }
+    flatMap<B>(fn: (_: A) => Monad<B>): Monad<B> {
+        return this.chain(fn);
+    }
+}
+
+export interface StaticMonad<A> extends StaticApplicative<A> {
+    of(_: A): Monad<A>
+}

--- a/source/abstract/semigroup.ts
+++ b/source/abstract/semigroup.ts
@@ -1,0 +1,14 @@
+/*
+----------------------------------------------------------------------
+
+ This source file is part of the Folktale project.
+
+ Licensed under MIT. See LICENCE for full licence information.
+ See CONTRIBUTORS for the list of contributors to the project.
+
+----------------------------------------------------------------------
+*/
+
+export type Semigroup<A> = A & {
+    concat(this: Semigroup<A>, that: Semigroup<A>): Semigroup<A>
+};

--- a/source/decorators/staticImplements.ts
+++ b/source/decorators/staticImplements.ts
@@ -1,0 +1,15 @@
+/*
+----------------------------------------------------------------------
+
+ This source file is part of the Folktale project.
+
+ Licensed under MIT. See LICENCE for full licence information.
+ See CONTRIBUTORS for the list of contributors to the project.
+
+----------------------------------------------------------------------
+*/
+
+/* class decorator to enforce implementation of static methods */
+export function staticImplements<T>() {
+    return (constructor: T) => {};
+}


### PR DESCRIPTION
This commit adds some basic typescript abstractions for Functors, Applicatives, Monads, and Semigroups.

Most of the abstractions are as abstract typescript classes. The reason for this design decision is that certain derived methods can be added automatically by simply extending these classes (for instance, the applicative `apply` method is added automatically once one overrides `map` and `chain` in a Monad).

ToDo: Add derivations for fantasyland synonymous methods from the basic methods.