### PR TITLE
Fixes debug representation for numbers

### DIFF
--- a/packages/base/source/adt/union/derivations/debug-representation.js
+++ b/packages/base/source/adt/union/derivations/debug-representation.js
@@ -71,6 +71,8 @@ const objectToString = (object) =>
 const showValue = (value) =>
     typeof value === 'undefined' ?  'undefined'
   : typeof value === 'function'  ?  functionToString(value)
+  : Object.is(value, -0)         ?  '-0'
+  : typeof value === 'number'    ?  value
   : typeof value === 'symbol'    ?  value.toString()
   : typeof value === 'object'    ?  objectToString(value).call(value)
   : /* otherwise */                 JSON.stringify(value);

--- a/test/source/specs/base/adt/union.js
+++ b/test/source/specs/base/adt/union.js
@@ -196,6 +196,12 @@ describe('ADT: union', () => {
     property('Primitive Values have a string representation', () => {
       return AB.A(1).toString()  === 'AB.A({ value: 1 })';
     })
+    property('Special IEEE 754 values have a correct string representation', () => {
+      return AB.A(NaN).toString() === 'AB.A({ value: NaN })'
+      &&     AB.A(Infinity).toString() === 'AB.A({ value: Infinity })'
+      &&     AB.A(-Infinity).toString() === 'AB.A({ value: -Infinity })'
+      &&     AB.A(-0).toString() === 'AB.A({ value: -0 })'
+    })
     property('Complex Values have a string representation', () => {
       return AB.A({foo: "bar"}).toString()  === 'AB.A({ value: { foo: "bar" } })';
     })


### PR DESCRIPTION
Previously JSON.stringify was used for representing numbers, but that doesn't work with special IEEE754 values like NaN and Infinity.

This fixes #191