### PR TITLE
Adds a chain function to Validation

### DIFF
--- a/annotations/source/en/validation/chain.md
+++ b/annotations/source/en/validation/chain.md
@@ -1,0 +1,21 @@
+@annotate: folktale.validation.chain
+category: Transforming
+---
+
+Transforms the value and context of a Validation computation with an unary function.
+As with `.map()`, the transformation is only applied if the value is a `Success`,
+but the transformation is expected a new `Validation` value, which then becomes the
+result of the function.
+
+## Example::
+
+    const { Success, Failure, chain } = require('folktale/validation');
+
+    chain(Success('a'), x => Success(x.toUpperCase()));
+    // ==> Success('A')
+
+    chain(Success('a'), x => Failure(x));
+    // ==> Failure('a')
+
+    chain(Failure('a'), x => Success(x.toUpperCase()));
+    // ==> Failure('a')

--- a/packages/base/source/validation/chain.js
+++ b/packages/base/source/validation/chain.js
@@ -18,7 +18,7 @@ const chain = (validation, fn) =>
   validation.matchWith({
     Success: ({ value }) => fn(value),
     Failure: ({ value }) => Failure(value)
-  })
+  });
 
 
 module.exports = chain;

--- a/packages/base/source/validation/chain.js
+++ b/packages/base/source/validation/chain.js
@@ -1,0 +1,24 @@
+//----------------------------------------------------------------------
+//
+// This source file is part of the Folktale project.
+//
+// Licensed under MIT. See LICENCE for full licence information.
+// See CONTRIBUTORS for the list of contributors to the project.
+//
+//----------------------------------------------------------------------
+
+const { Failure } = require('./validation');
+
+/*~
+ * stability: experimental
+ * type: |
+ *   forall a, b, c: (Validation a b, (b) => Validation a c) => Validation a c
+ */
+const chain = (validation, fn) =>
+  validation.matchWith({
+    Success: ({ value }) => fn(value),
+    Failure: ({ value }) => Failure(value)
+  })
+
+
+module.exports = chain;

--- a/packages/base/source/validation/index.js
+++ b/packages/base/source/validation/index.js
@@ -23,6 +23,7 @@ module.exports = {
   fromJSON: Validation.fromJSON,
   [typeSymbol]: Validation[typeSymbol],
   collect: require('./collect'),
+  chain: require('./chain'),
 
   /*~
    * type: |

--- a/test/source/specs/base/validation/validation.js
+++ b/test/source/specs/base/validation/validation.js
@@ -41,11 +41,11 @@ describe('Validation', () => {
     const lift = (f) => a => _.of(f(a));
 
     property('chain', 'json', 'json -> json', (a, f) => {
-      return _.chain(_.Success(x), lift(f)).equals(lift(f)(a));
+      return _.chain(_.Success(a), lift(f)).equals(lift(f)(a));
     });
 
     property('chain Failure', 'json', 'json -> json', (a, f) => {
-      return _.chain(_.Failure(x), lift(f)).equals(_.Failure(x));
+      return _.chain(_.Failure(a), lift(f)).equals(_.Failure(a));
     });
   });
 

--- a/test/source/specs/base/validation/validation.js
+++ b/test/source/specs/base/validation/validation.js
@@ -37,6 +37,18 @@ describe('Validation', () => {
     });
   });
 
+  describe('chain(validation, fn)', () => {
+    const lift = (f) => a => _.of(f(a));
+
+    property('chain', 'json', 'json -> json', (a, f) => {
+      return _.chain(_.Success(x), lift(f)).equals(lift(f)(a));
+    });
+
+    property('chain Failure', 'json', 'json -> json', (a, f) => {
+      return _.chain(_.Failure(x), lift(f)).equals(_.Failure(x));
+    });
+  });
+
   describe('Functor', () => {
     property('map', 'json', 'json -> json', (a, f) => {
       return _.of(f(a)).equals(_.of(a).map(f))


### PR DESCRIPTION
This allows manipulating Success in a simpler way than the full-blown matchWith without interfering with the Applicative instance. Addresses #175 