### PR TITLE
Fixes deferred state message.

### DIFF
--- a/packages/base/source/concurrency/future/_deferred.js
+++ b/packages/base/source/concurrency/future/_deferred.js
@@ -23,7 +23,7 @@ const describeState = (state) => {
     Rejected:  _ => 'rejected',
     Cancelled: _ => 'cancelled'
   });
-}
+};
 
 /*~
  * type: |

--- a/packages/base/source/concurrency/future/_deferred.js
+++ b/packages/base/source/concurrency/future/_deferred.js
@@ -17,18 +17,21 @@ const { Pending, Cancelled, Rejected, Resolved } = require('./_execution-state')
 
 // --[ Helpers ]-------------------------------------------------------
 
+const describeState = (state) => {
+  return state.matchWith({
+    Resolved:  _ => 'resolved',
+    Rejected:  _ => 'rejected',
+    Cancelled: _ => 'cancelled'
+  });
+}
+
 /*~
  * type: |
  *   ('a: Deferred 'f 's, ExecutionState 'f 's) => Void :: mutates 'a
  */
 const moveToState = (deferred, newState) => {
   if (!Pending.hasInstance(deferred._state)) {
-    const description = newState.matchWith({
-      Resolved:  _ => 'resolved',
-      Rejected:  _ => 'rejected',
-      Cancelled: _ => 'cancelled'
-    });
-    throw new Error(`Only pending deferreds can be ${description}, this deferred is already ${description}.`);
+    throw new Error(`Only pending deferreds can be ${describeState(newState)}, this deferred is already ${describeState(deferred._state)}.`);
   }
 
   deferred._state = newState;


### PR DESCRIPTION
When we try to settle a deferred that's already settled we get a message saying that it's not possible to move to the new state, because the current state is not "pending"... except it described the new state where it should describe the old one. Ooops!

This addresses part of the last comment in #153