### PR TITLE
Use ES6 module imports in webpack example

### DIFF
--- a/docs/_docs/v2.3.0/download.md
+++ b/docs/_docs/v2.3.0/download.md
@@ -116,11 +116,11 @@ Then install Folktale through npm as well:
 Ideally, require only the Folktale modules you'll be using. This helps keeping the overall size smaller. For example, if you're using only the `Maybe` and `compose` functions, don't load the library's entry-point, just those modules:
 
 ```js
-const Maybe = require('folktale/maybe');
-const compose = require('folktale/core/lambda/compose');
+import Maybe from 'folktale/maybe';
+import compose from 'folktale/core/lambda/compose';
 
-const inc = (x) => x + 1;
-const double = (x) => x * 2;
+const inc = x => x + 1;
+const double = x => x * 2;
 
 Maybe.Just(1).map(compose(double, inc));
 // ==> Maybe.Just(4)


### PR DESCRIPTION
Nowadays webpack is used in conjunction with ES6 module imports. The proposed syntax has been tested and it works flawlessly.